### PR TITLE
Chaos CI Phase 1: pause, crash/recovery, disk-full

### DIFF
--- a/.github/workflows/chaos-ci.yml
+++ b/.github/workflows/chaos-ci.yml
@@ -22,6 +22,11 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install Python deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests
+
       - name: Build and run chaos stack
         run: |
           docker version
@@ -44,4 +49,3 @@ jobs:
         if: always()
         run: |
           docker compose -f docker-compose.yml -f AgentStateTesting/chaos/docker-compose.chaos.yml down -v || true
-

--- a/.github/workflows/chaos-ci.yml
+++ b/.github/workflows/chaos-ci.yml
@@ -1,0 +1,47 @@
+name: Chaos CI
+
+on:
+  push:
+    branches: [ "feature/chaos-ci-*", "chaos/*" ]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  schedule:
+    - cron: '0 6 * * *'  # daily 6:00 UTC
+
+jobs:
+  chaos:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Build and run chaos stack
+        run: |
+          docker version
+          docker compose -f docker-compose.yml -f AgentStateTesting/chaos/docker-compose.chaos.yml up -d --build
+
+      - name: Run chaos suite
+        env:
+          CAP_KEY_ACTIVE: dev-secret
+          CAP_KEY_ACTIVE_ID: active
+        run: |
+          python AgentStateTesting/chaos/chaos_runner.py
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: |
+          docker logs agentstate-chaos || true
+          ls -la data || true
+
+      - name: Teardown
+        if: always()
+        run: |
+          docker compose -f docker-compose.yml -f AgentStateTesting/chaos/docker-compose.chaos.yml down -v || true
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,29 +15,27 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@1.81.0
       with:
-        toolchain: 1.81.0
-        profile: minimal
-        override: true
-    
+        components: rustfmt, clippy
+
     - name: Install protoc
       run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-    
+
     - name: Cache dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
           target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    
+
     - name: Check formatting
       run: cargo fmt --all -- --check
-    
+
     - name: Clippy
-      run: cargo clippy --all-targets --all-features -- -D warnings
+      run: cargo clippy --all-targets --all-features -- -D clippy::correctness -D clippy::suspicious -W clippy::complexity
     
     - name: Run tests
       run: cargo test --all

--- a/AgentStateTesting/chaos/Dockerfile.chaos
+++ b/AgentStateTesting/chaos/Dockerfile.chaos
@@ -6,9 +6,8 @@ RUN cargo build --release -p agentstate-server
 
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates curl iproute2 procps coreutils && \
+    ca-certificates curl iproute2 procps coreutils bash util-linux && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/target/release/agentstate-server /agentstate-server
 EXPOSE 8080 9090
 ENTRYPOINT ["/agentstate-server"]
-

--- a/AgentStateTesting/chaos/Dockerfile.chaos
+++ b/AgentStateTesting/chaos/Dockerfile.chaos
@@ -1,0 +1,14 @@
+FROM rust:1.81 as builder
+RUN apt-get update && apt-get install -y protobuf-compiler && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY . .
+RUN cargo build --release -p agentstate-server
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl iproute2 procps coreutils && \
+    rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/agentstate-server /agentstate-server
+EXPOSE 8080 9090
+ENTRYPOINT ["/agentstate-server"]
+

--- a/AgentStateTesting/chaos/README.md
+++ b/AgentStateTesting/chaos/README.md
@@ -1,0 +1,26 @@
+Chaos Testing (Phase 1)
+
+Goals
+- Exercise single-node durability and availability under faults.
+- Automate repeatable nemeses: pause (partition surrogate), crash/recovery, disk-full.
+- Run in CI on PRs and nightly without touching production images.
+
+How It Works
+- Uses a compose overlay that swaps in a Debian runtime image for the server, adds tmpfs for `/data` (size-limited), and assigns a stable container name `agentstate-chaos`.
+- Python runner starts the stack, warms with a steady workload, then injects nemeses while validating:
+  - Crash/Recovery: `docker kill` then restart; ensure committed objects are readable after restart.
+  - Pause/Unpause: `docker pause` to simulate a stall/partition; workload should back off and recover without data loss.
+  - Disk-Full: fill `/data` inside the container to trigger ENOSPC; verify server surfaces errors without crashing, and recovers once space is freed.
+
+Usage (local)
+- Build and run:
+  - `docker compose -f docker-compose.yml -f AgentStateTesting/chaos/docker-compose.chaos.yml up -d --build`
+  - `python AgentStateTesting/chaos/chaos_runner.py`
+  - `docker compose -f docker-compose.yml -f AgentStateTesting/chaos/docker-compose.chaos.yml down -v`
+
+CI
+- `.github/workflows/chaos-ci.yml` runs the chaos suite on PRs labeled `chaos` and nightly via cron. Artifacts (logs, data manifest) are uploaded on failure.
+
+Notes
+- Phase 1 targets single-node. Partition tests for multi-node will be added after clustering (see docs/jepsen.md).
+

--- a/AgentStateTesting/chaos/chaos_runner.py
+++ b/AgentStateTesting/chaos/chaos_runner.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+import os
+import sys
+import time
+import json
+import signal
+import subprocess
+from pathlib import Path
+
+import requests
+
+from nemeses import ensure_up, ensure_down, pause, kill, fill_disk, free_disk
+from workload import Workload
+
+ROOT = Path(__file__).resolve().parents[2]
+COMPOSE = [str(ROOT / 'docker-compose.yml'), str(ROOT / 'AgentStateTesting/chaos/docker-compose.chaos.yml')]
+CONTAINER = 'agentstate-chaos'
+BASE_URL = os.environ.get('AGENTSTATE_BASE_URL', 'http://localhost:8080')
+NAMESPACE = os.environ.get('AGENTSTATE_NS', 'chaos')
+
+
+def wait_healthy(timeout=60):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            r = requests.get(f"{BASE_URL}/health", timeout=2)
+            if r.status_code == 200:
+                return True
+        except Exception:
+            pass
+        time.sleep(1)
+    return False
+
+
+def gen_token(namespaces, verbs):
+    # prefer using the helper script
+    kid = os.environ.get('CAP_KEY_ACTIVE_ID', 'active')
+    secret = os.environ.get('CAP_KEY_ACTIVE', 'dev-secret')
+    cmd = [sys.executable, str(ROOT / 'scripts/generate_cap_token.py'),
+           '--kid', kid, '--secret', secret]
+    for ns in namespaces:
+        cmd += ['--ns', ns]
+    for v in verbs:
+        cmd += ['--verb', v]
+    out = subprocess.check_output(cmd).decode().strip()
+    return out
+
+
+def main():
+    # Bring up stack
+    ensure_up(COMPOSE)
+    try:
+        if not wait_healthy(90):
+            print('error: server did not become healthy', file=sys.stderr)
+            return 2
+
+        token = gen_token([NAMESPACE], ['put', 'get', 'delete', 'query', 'lease', 'admin'])
+        wl = Workload(BASE_URL, token, NAMESPACE)
+        wl.start(writers=4, readers=2)
+
+        # Warm up
+        time.sleep(3)
+
+        # Nemesis: pause/unpause
+        print('nemesis: pause/unpause for 5s')
+        pause(CONTAINER, seconds=5)
+        time.sleep(2)
+
+        # Nemesis: crash/recovery
+        print('nemesis: crash (kill) then restart')
+        kill(CONTAINER)
+        ensure_up(COMPOSE)
+        if not wait_healthy(60):
+            print('error: server did not recover after crash', file=sys.stderr)
+            return 2
+        time.sleep(2)
+
+        # Nemesis: disk-full (64MiB tmpfs). Fill ~56MiB to force ENOSPC quickly.
+        print('nemesis: disk-full simulation (fill tmpfs)')
+        bytes_to_fill = 56 * 1024 * 1024
+        fill_disk(CONTAINER, bytes_to_fill)
+        # Try a few writes, allow failures, but ensure process stays healthy
+        fail_count = 0
+        for _ in range(20):
+            ok = wl.put_once('df-key', _)
+            if not ok:
+                fail_count += 1
+            time.sleep(0.05)
+        if fail_count == 0:
+            print('warning: disk-full not observed (runner may have more space). Continuing.', file=sys.stderr)
+        # Free space and verify writes succeed again
+        free_disk(CONTAINER)
+        recovered = False
+        for _ in range(30):
+            if wl.put_once('df-key', _):
+                recovered = True
+                break
+            time.sleep(0.1)
+        if not recovered:
+            print('error: writes did not recover after freeing space', file=sys.stderr)
+            return 2
+
+        print('chaos run completed')
+        return 0
+    finally:
+        wl.stop_all() if 'wl' in locals() else None
+        ensure_down(COMPOSE)
+
+
+if __name__ == '__main__':
+    sys.exit(main())
+

--- a/AgentStateTesting/chaos/docker-compose.chaos.yml
+++ b/AgentStateTesting/chaos/docker-compose.chaos.yml
@@ -1,0 +1,16 @@
+version: '3.9'
+services:
+  agentstate:
+    container_name: agentstate-chaos
+    build:
+      context: .
+      dockerfile: AgentStateTesting/chaos/Dockerfile.chaos
+    tmpfs:
+      - /data:rw,size=64m
+    environment:
+      DATA_DIR: /data
+      DEV_MODE: "1"
+      REGION: "us-west-2"
+      CAP_KEY_ACTIVE_ID: ${CAP_KEY_ACTIVE_ID:-active}
+      CAP_KEY_ACTIVE: ${CAP_KEY_ACTIVE:-dev-secret}
+

--- a/AgentStateTesting/chaos/nemeses.py
+++ b/AgentStateTesting/chaos/nemeses.py
@@ -1,0 +1,42 @@
+import os
+import subprocess
+import time
+import shlex
+
+
+def sh(cmd: str, check=True) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, shell=True, check=check, capture_output=True, text=True)
+
+
+def pause(container: str, seconds: int = 5):
+    sh(f"docker pause {shlex.quote(container)}")
+    time.sleep(seconds)
+    sh(f"docker unpause {shlex.quote(container)}")
+
+
+def kill(container: str):
+    # SIGKILL to simulate crash
+    sh(f"docker kill {shlex.quote(container)}")
+
+
+def ensure_up(compose_files):
+    files = " ".join(f"-f {shlex.quote(f)}" for f in compose_files)
+    sh(f"docker compose {files} up -d --build")
+
+
+def ensure_down(compose_files):
+    files = " ".join(f"-f {shlex.quote(f)}" for f in compose_files)
+    sh(f"docker compose {files} down -v || true", check=False)
+
+
+def fill_disk(container: str, target_bytes: int):
+    # write a large file in /data inside the container
+    # fallocate if available, otherwise dd
+    cmd = f"bash -lc 'command -v fallocate >/dev/null 2>&1 && fallocate -l {target_bytes} /data/fill || dd if=/dev/zero of=/data/fill bs=1M count=$(( {target_bytes} / 1048576 )) conv=fsync'"
+    # run via sh to allow bash -lc; Debian image has bash
+    sh(f"docker exec {shlex.quote(container)} {cmd}")
+
+
+def free_disk(container: str):
+    sh(f"docker exec {shlex.quote(container)} rm -f /data/fill || true", check=False)
+

--- a/AgentStateTesting/chaos/workload.py
+++ b/AgentStateTesting/chaos/workload.py
@@ -1,0 +1,87 @@
+import os
+import threading
+import time
+import json
+import random
+import string
+from typing import Dict, Tuple
+
+import requests
+
+
+def _rand(n: int = 8) -> str:
+    return ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(n))
+
+
+class Workload:
+    def __init__(self, base_url: str, token: str, namespace: str = "chaos"):
+        self.base_url = base_url.rstrip('/')
+        self.ns = namespace
+        self.token = token
+        self.session = requests.Session()
+        self.session.headers["Authorization"] = f"Bearer {self.token}" if self.token else ""
+        self.stop = threading.Event()
+        self.state_lock = threading.Lock()
+        # tracked latest values per key: (version, body)
+        self.latest: Dict[str, Tuple[int, dict]] = {}
+
+    def put_once(self, key: str, version: int) -> bool:
+        body = {"id": key, "ns": self.ns, "type": "note", "body": {"msg": f"v{version}"}}
+        try:
+            r = self.session.post(f"{self.base_url}/v1/{self.ns}/objects", json=body, timeout=5)
+            ok = r.status_code == 200
+            if ok:
+                with self.state_lock:
+                    self.latest[key] = (version, body["body"])  # track intended body
+            return ok
+        except Exception:
+            return False
+
+    def get_and_check(self, key: str) -> bool:
+        try:
+            r = self.session.get(f"{self.base_url}/v1/{self.ns}/objects/{key}", timeout=5)
+            if r.status_code != 200:
+                return False
+            data = r.json()
+            with self.state_lock:
+                expected = self.latest.get(key)
+            if not expected:
+                return True
+            _, body = expected
+            return data.get("body") == body
+        except Exception:
+            return False
+
+    def writer(self, keys=16, delay=0.01):
+        versions = [0] * keys
+        ids = [f"k-{i}-{_rand(4)}" for i in range(keys)]
+        while not self.stop.is_set():
+            idx = random.randrange(keys)
+            versions[idx] += 1
+            self.put_once(ids[idx], versions[idx])
+            time.sleep(delay)
+
+    def reader(self, keys=16, delay=0.01):
+        ids = [f"k-{i}" for i in range(keys)]
+        while not self.stop.is_set():
+            # check a random known key if present
+            key = random.choice(list(self.latest.keys()) or [f"k-0"])
+            self.get_and_check(key)
+            time.sleep(delay)
+
+    def start(self, writers=2, readers=2):
+        self.threads = []
+        for _ in range(writers):
+            t = threading.Thread(target=self.writer, daemon=True)
+            t.start()
+            self.threads.append(t)
+        for _ in range(readers):
+            t = threading.Thread(target=self.reader, daemon=True)
+            t.start()
+            self.threads.append(t)
+
+    def stop_all(self):
+        self.stop.set()
+        for t in self.threads:
+            t.join(timeout=2)
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "crates/agentstate-storage",
   "crates/agentstate-server",
   "crates/agentstate-cli",
+  "crates/agentstate-verify",
 ]
 resolver = "2"
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,34 @@
 # 🤖 AgentState v1.0.0
-**Firebase for AI Agents** — Persistent state management for AI applications
+**Firebase for AI Agents** — Persistent, verifiable state management for AI applications
 
 [![Docker Build](https://img.shields.io/badge/docker-ready-blue)](#docker-deployment)
-[![API Status](https://img.shields.io/badge/api-stable-green)](#api-reference)  
+[![API Status](https://img.shields.io/badge/api-stable-green)](#api-reference)
 [![Load Tested](https://img.shields.io/badge/load%20tested-1400%20ops%2Fs-brightgreen)](#performance)
+[![Formally Verifiable](https://img.shields.io/badge/formally-verifiable-purple)](#-formal-verifiability)
 [![Python SDK](https://img.shields.io/badge/python-pypi-blue)](https://pypi.org/project/agentstate/)
 [![Node.js SDK](https://img.shields.io/badge/nodejs-npm-green)](https://www.npmjs.com/package/agentstate)
 
-AgentState provides a simple, scalable way to store and manage AI agent state with real-time updates, rich querying, and built-in persistence. Think Firebase for your AI agents.
+AgentState provides a simple, scalable way to store and manage AI agent state with real-time updates, rich querying, built-in persistence, and cryptographic behavioral proof. Think Firebase for your AI agents — with the auditability of a blockchain.
 
 **🚀 Key Features:**
 - **Zero-config setup** — Docker one-liner gets you started
-- **Language agnostic** — HTTP/gRPC APIs + Python/Node.js SDKs  
+- **Language agnostic** — HTTP/gRPC APIs + Python/Node.js/Go SDKs
 - **High performance** — 1,400+ ops/sec with crash-safe persistence
 - **Real-time queries** — Find agents by tags, get live updates
 - **Production ready** — Load tested, monitored, Kubernetes friendly
+- **Formally verifiable** — Prove your agents always behave correctly
 
 ## ✨ Features
 
 - 🔄 **Real-time state updates** - Subscribe to agent state changes
-- 🏷️ **Rich querying** - Query agents by tags and attributes  
+- 🏷️ **Rich querying** - Query agents by tags and attributes
 - 💾 **Persistent storage** - Crash-safe WAL + snapshots
 - ⚡ **High performance** - 1,400+ ops/sec, ~15ms latency
 - 🐳 **Production ready** - Docker, Kubernetes, monitoring
 - 🔌 **Simple API** - HTTP REST + gRPC, language agnostic
+- 🔐 **Tamper-evident** - blake3 hash chain across every commit
+- 📋 **Runtime invariants** - Reject bad writes before they happen
+- 🔬 **Temporal verification** - LTL property checking over full WAL traces
 
 ## 🚀 Quick Start
 
@@ -125,6 +130,90 @@ curl -X POST http://localhost:8080/v1/my-app/query \
   -H "Content-Type: application/json" \
   -d '{"tags": {"env": "prod"}}'
 ```
+
+## 🔬 Formal Verifiability
+
+AgentState is the only open-source AI agent state store that can **prove** your agents behave correctly. Three complementary layers:
+
+### Layer 1 — Tamper-Evident Hash Chain
+
+Every write extends a blake3 hash chain. Each commit's hash includes the previous commit hash and a monotonic sequence number, making any WAL tampering or reordering cryptographically detectable.
+
+```bash
+# Verify the full chain for a namespace
+curl http://localhost:8080/admin/namespaces/production/chain-verify
+# → { "ok": true, "objects_checked": 1842, "breaks": [] }
+```
+
+Objects include a `prev_commit` field linking back to the previous version — giving you a full provenance trail for every agent.
+
+### Layer 2 — Runtime Invariant Assertions
+
+Define a predicate spec for a namespace. Every write is validated before it's accepted — violations are rejected with a structured 409.
+
+```bash
+# Set invariant: status must be one of these values, score must be in [0, 1]
+curl -X POST http://localhost:8080/admin/namespaces/production/invariants \
+  -H "Content-Type: application/json" \
+  -d '{
+    "rules": [
+      { "field": "body.status", "required": true, "one_of": ["active", "idle", "stopped"] },
+      { "field": "body.score",  "gte": 0.0, "lte": 1.0 },
+      { "field": "body.agent_id", "required": true, "type": "string" }
+    ]
+  }'
+```
+
+**Supported predicates:** `required`, `type`, `eq`, `one_of`, `gte`/`lte`/`gt`/`lt`, `regex`
+
+Specs are WAL-persisted and replayed on restart — invariants survive server crashes.
+
+**Python SDK:**
+```python
+client.set_invariant("production", [
+    {"field": "body.status", "one_of": ["active", "idle", "stopped"]},
+    {"field": "body.score",  "gte": 0.0, "lte": 1.0},
+])
+```
+
+### Layer 3 — Temporal Property Checking (LTL)
+
+Write formal properties as JSON files, then verify them over your full WAL execution trace — offline, in CI, or post-incident.
+
+```json
+// props/liveness.ltl.json
+{
+  "name": "active_agents_eventually_idle",
+  "kind": "liveness",
+  "description": "Any agent that becomes 'active' must eventually become 'idle' or 'stopped'",
+  "forall": { "type": "agent" },
+  "leads_to": {
+    "if":   { "field": "body.status", "eq": "active" },
+    "then": { "eventually": { "or": [
+      { "field": "body.status", "eq": "idle" },
+      { "field": "body.status", "eq": "stopped" }
+    ]}}
+  }
+}
+```
+
+```bash
+# Run in CI — exits 1 if any property is violated
+agentstate-cli verify \
+  --dir /data/wal \
+  --ns production \
+  --property props/liveness.ltl.json \
+  --property props/no_unknown_status.ltl.json \
+  --fail-on-violation
+```
+
+Output is a structured JSON report with counterexample traces for each violation.
+
+**Supported temporal operators:** `always`, `eventually`, `leads_to`, `until`, `not`, `and`, `or`
+
+> **EU AI Act compliance** — This directly supports Article 9 (risk management systems), Article 13 (transparency and traceability), and Article 72 (post-market monitoring). See [docs/verification.md](docs/verification.md) for the full mapping.
+
+---
 
 ## 🤖 AI Framework Integration
 
@@ -228,6 +317,9 @@ team_agents = requests.post("http://localhost:8080/v1/production/query", json={
 | `DELETE` | `/v1/{ns}/objects/{id}` | Delete agent |
 | `GET` | `/health` | Health check |
 | `GET` | `/metrics` | Prometheus metrics |
+| `GET` | `/admin/namespaces/{ns}/chain-verify` | Verify full hash chain |
+| `POST` | `/admin/namespaces/{ns}/invariants` | Set namespace invariant spec |
+| `GET` | `/admin/namespaces/{ns}/invariants` | Get current invariant spec |
 
 ## 🐳 Docker Deployment
 
@@ -344,6 +436,7 @@ docker build -f docker/Dockerfile -t ayushmi/agentstate:latest .
 ## 📚 Documentation
 
 - **[📖 Quickstart Guide](QUICKSTART.md)** - Detailed getting started
+- **[🔬 Verification Guide](docs/verification.md)** - Hash chains, invariants, LTL, EU AI Act mapping
 - **[🗺️ Roadmap](docs/ROADMAP.md)** - Priorities, dependencies, milestones
 - **[🏗️ Architecture](docs/architecture.md)** - System design
 - **[🚀 Deployment](docs/DEPLOY.md)** - Production setup
@@ -434,13 +527,16 @@ AgentState provides:
 - ✅ **Real-time updates** - Subscribe to state changes
 - ✅ **Production ready** - Monitoring, clustering, reliability
 - ✅ **Language agnostic** - Works with any HTTP client
+- ✅ **Formally verifiable** - Prove behavioral compliance, not just observe it
+- ✅ **Audit-ready** - Cryptographic proof of every state transition
 
 **Perfect for:**
 - Multi-agent AI systems
-- Agent monitoring dashboards  
+- Agent monitoring dashboards
 - Workflow orchestration
 - Real-time agent coordination
 - Production AI deployments
+- EU AI Act compliance infrastructure
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ AgentState provides a simple, scalable way to store and manage AI agent state wi
 
 ## 🚀 Quick Start
 
+Try it in your browser: see the Playground at `docs/playground/index.html` (works great with a local server on :8080). For a hosted path with simple billing, use the gateway in `gateway/` and click “Use Hosted (fetch token)” in the Playground.
+
 ### 1. Start AgentState Server
 
 **Option A: Using Docker (Recommended)**
@@ -342,6 +344,7 @@ docker build -f docker/Dockerfile -t ayushmi/agentstate:latest .
 ## 📚 Documentation
 
 - **[📖 Quickstart Guide](QUICKSTART.md)** - Detailed getting started
+- **[🗺️ Roadmap](docs/ROADMAP.md)** - Priorities, dependencies, milestones
 - **[🏗️ Architecture](docs/architecture.md)** - System design
 - **[🚀 Deployment](docs/DEPLOY.md)** - Production setup
 - **[📊 Monitoring](deploy/grafana/)** - Grafana dashboards

--- a/adapters/mcp/README.md
+++ b/adapters/mcp/README.md
@@ -1,0 +1,70 @@
+# agentstate-mcp
+
+MCP server that exposes [AgentState](https://github.com/ayushmi/agentstate) as persistent memory tools for Claude Desktop, Cursor, and any other MCP-compatible client.
+
+## Install
+
+```bash
+pip install agentstate-mcp
+```
+
+## Quick Start
+
+### 1. Start AgentState
+
+```bash
+docker run -p 8080:8080 ayushmi/agentstate:latest
+```
+
+### 2. Configure Claude Desktop
+
+Add to `~/.claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "agentstate-memory": {
+      "command": "agentstate-mcp",
+      "env": {
+        "AGENTSTATE_URL": "http://localhost:8080",
+        "AGENTSTATE_NAMESPACE": "claude-memories",
+        "AGENTSTATE_API_KEY": ""
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop. You'll see 5 new memory tools available.
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `store_memory` | Store information persistently with optional tags |
+| `retrieve_memory` | Retrieve a specific memory by ID |
+| `search_memories` | Search memories by tag filters |
+| `delete_memory` | Delete a memory by ID |
+| `list_memories` | List all memories, optionally filtered by tags |
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AGENTSTATE_URL` | `http://localhost:8080` | AgentState server URL |
+| `AGENTSTATE_NAMESPACE` | `mcp-memory` | Namespace for memory storage |
+| `AGENTSTATE_API_KEY` | _(none)_ | API key if auth is enabled |
+
+## Example Interaction
+
+Once configured, Claude can use persistent memory across conversations:
+
+> **You:** Remember that my project uses Python 3.11 and PostgreSQL 15.
+>
+> **Claude:** I'll store that. *(calls store_memory with tags {"project": "current"})*
+>
+> *(New conversation)*
+>
+> **You:** What database am I using?
+>
+> **Claude:** *(calls search_memories with tags {"project": "current"})* You're using PostgreSQL 15.

--- a/adapters/mcp/agentstate_mcp/__init__.py
+++ b/adapters/mcp/agentstate_mcp/__init__.py
@@ -1,0 +1,3 @@
+from .server import main
+
+__all__ = ["main"]

--- a/adapters/mcp/agentstate_mcp/server.py
+++ b/adapters/mcp/agentstate_mcp/server.py
@@ -1,0 +1,226 @@
+"""
+AgentState MCP Server
+
+Exposes AgentState as persistent memory tools for any MCP-compatible client
+(Claude Desktop, Cursor, custom agents, etc.).
+
+Configure via environment variables:
+    AGENTSTATE_URL        URL of the AgentState server (default: http://localhost:8080)
+    AGENTSTATE_NAMESPACE  Namespace for memory storage (default: mcp-memory)
+    AGENTSTATE_API_KEY    API key for authentication (optional)
+
+Run:
+    agentstate-mcp
+    # or
+    python -m agentstate_mcp.server
+
+Claude Desktop config (~/.claude/claude_desktop_config.json):
+    {
+      "mcpServers": {
+        "agentstate-memory": {
+          "command": "agentstate-mcp",
+          "env": {
+            "AGENTSTATE_URL": "http://localhost:8080",
+            "AGENTSTATE_NAMESPACE": "claude-memories"
+          }
+        }
+      }
+    }
+"""
+
+import asyncio
+import json
+import os
+import sys
+from typing import Any
+
+from agentstate import AgentStateClient
+
+try:
+    import mcp.server.stdio
+    import mcp.types as types
+    from mcp.server import Server
+except ImportError as e:
+    raise ImportError(
+        "mcp is required. Install it with: pip install mcp"
+    ) from e
+
+AGENTSTATE_URL = os.environ.get("AGENTSTATE_URL", "http://localhost:8080")
+AGENTSTATE_NAMESPACE = os.environ.get("AGENTSTATE_NAMESPACE", "mcp-memory")
+AGENTSTATE_API_KEY = os.environ.get("AGENTSTATE_API_KEY")
+
+_client = AgentStateClient(
+    base_url=AGENTSTATE_URL,
+    namespace=AGENTSTATE_NAMESPACE,
+    api_key=AGENTSTATE_API_KEY,
+)
+
+app = Server("agentstate-memory")
+
+
+@app.list_tools()
+async def list_tools() -> list[types.Tool]:
+    return [
+        types.Tool(
+            name="store_memory",
+            description=(
+                "Store a memory or piece of information persistently in AgentState. "
+                "Returns the memory ID for later retrieval."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "content": {
+                        "type": "string",
+                        "description": "The content or information to store",
+                    },
+                    "tags": {
+                        "type": "object",
+                        "description": "Optional key-value tags for categorization and retrieval",
+                        "additionalProperties": {"type": "string"},
+                    },
+                    "memory_id": {
+                        "type": "string",
+                        "description": "Optional stable ID — if provided, updates the memory in place on subsequent calls",
+                    },
+                },
+                "required": ["content"],
+            },
+        ),
+        types.Tool(
+            name="retrieve_memory",
+            description="Retrieve a specific memory by its ID.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "memory_id": {
+                        "type": "string",
+                        "description": "The ID of the memory to retrieve",
+                    },
+                },
+                "required": ["memory_id"],
+            },
+        ),
+        types.Tool(
+            name="search_memories",
+            description=(
+                "Search stored memories by tags. All provided tags must match. "
+                "Returns a list of matching memories."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "tags": {
+                        "type": "object",
+                        "description": "Tag filters — only memories matching ALL tags are returned",
+                        "additionalProperties": {"type": "string"},
+                    },
+                },
+                "required": [],
+            },
+        ),
+        types.Tool(
+            name="delete_memory",
+            description="Permanently delete a memory by ID.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "memory_id": {
+                        "type": "string",
+                        "description": "The ID of the memory to delete",
+                    },
+                },
+                "required": ["memory_id"],
+            },
+        ),
+        types.Tool(
+            name="list_memories",
+            description="List all stored memories, optionally filtered by tags.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "tags": {
+                        "type": "object",
+                        "description": "Optional tag filters",
+                        "additionalProperties": {"type": "string"},
+                    },
+                },
+                "required": [],
+            },
+        ),
+    ]
+
+
+@app.call_tool()
+async def call_tool(name: str, arguments: dict[str, Any]) -> list[types.TextContent]:
+    try:
+        if name == "store_memory":
+            tags = arguments.get("tags") or {}
+            obj = _client.create_agent(
+                agent_type="memory",
+                body={"content": arguments["content"]},
+                tags=tags,
+                agent_id=arguments.get("memory_id"),
+                cause={"actor": "mcp-client", "note": "stored via MCP tool"},
+            )
+            return [types.TextContent(
+                type="text",
+                text=f"Memory stored successfully.\nID: {obj['id']}\nUse this ID to retrieve or update it later.",
+            )]
+
+        elif name == "retrieve_memory":
+            obj = _client.get_agent(arguments["memory_id"])
+            content = obj.get("body", {}).get("content", "")
+            return [types.TextContent(
+                type="text",
+                text=f"Memory (ID: {obj['id']}):\n{content}",
+            )]
+
+        elif name == "search_memories":
+            tags = arguments.get("tags") or {}
+            results = _client.query_agents(tags=tags if tags else None)
+            if not results:
+                return [types.TextContent(type="text", text="No memories found matching the given tags.")]
+            lines = []
+            for obj in results:
+                content = obj.get("body", {}).get("content", "")
+                lines.append(f"[{obj['id']}] {content}")
+            return [types.TextContent(type="text", text="\n".join(lines))]
+
+        elif name == "delete_memory":
+            _client.delete_agent(arguments["memory_id"])
+            return [types.TextContent(
+                type="text",
+                text=f"Memory {arguments['memory_id']} deleted.",
+            )]
+
+        elif name == "list_memories":
+            tags = arguments.get("tags") or {}
+            results = _client.query_agents(tags=tags if tags else None)
+            if not results:
+                return [types.TextContent(type="text", text="No memories stored yet.")]
+            lines = []
+            for obj in results:
+                content = obj.get("body", {}).get("content", "")
+                tag_str = ", ".join(f"{k}={v}" for k, v in obj.get("tags", {}).items())
+                lines.append(f"[{obj['id']}] {content[:80]}{'...' if len(content) > 80 else ''} ({tag_str})")
+            return [types.TextContent(type="text", text="\n".join(lines))]
+
+        else:
+            return [types.TextContent(type="text", text=f"Unknown tool: {name}")]
+
+    except Exception as e:
+        return [types.TextContent(type="text", text=f"Error: {e}")]
+
+
+async def _run():
+    async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):
+        await app.run(read_stream, write_stream, app.create_initialization_options())
+
+
+def main():
+    asyncio.run(_run())
+
+
+if __name__ == "__main__":
+    main()

--- a/adapters/mcp/claude_desktop_config.json.example
+++ b/adapters/mcp/claude_desktop_config.json.example
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "agentstate-memory": {
+      "command": "agentstate-mcp",
+      "env": {
+        "AGENTSTATE_URL": "http://localhost:8080",
+        "AGENTSTATE_NAMESPACE": "claude-memories",
+        "AGENTSTATE_API_KEY": ""
+      }
+    }
+  }
+}

--- a/adapters/mcp/pyproject.toml
+++ b/adapters/mcp/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.backends.legacy:build"
+
+[project]
+name = "agentstate-mcp"
+version = "0.1.0"
+description = "MCP server exposing AgentState as persistent memory tools for Claude and other MCP clients"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "agentstate>=1.0.2",
+    "mcp>=1.0.0",
+]
+
+[project.scripts]
+agentstate-mcp = "agentstate_mcp.server:main"
+
+[project.urls]
+Homepage = "https://github.com/ayushmi/agentstate"

--- a/adapters/python/langgraph_agentstate/README.md
+++ b/adapters/python/langgraph_agentstate/README.md
@@ -1,0 +1,68 @@
+# langgraph-agentstate
+
+LangGraph checkpoint saver backed by [AgentState](https://github.com/ayushmi/agentstate).
+
+Persist and resume any LangGraph graph across process restarts with one line of code.
+
+## Install
+
+```bash
+pip install langgraph-agentstate
+```
+
+## Quick Start
+
+```python
+from agentstate import AgentStateClient
+from langgraph_agentstate import AgentStateCheckpointSaver
+from langgraph.graph import StateGraph, END
+from typing import TypedDict
+
+class State(TypedDict):
+    messages: list
+    step: int
+
+# 1. Connect to AgentState
+client = AgentStateClient("http://localhost:8080", namespace="default")
+saver = AgentStateCheckpointSaver(client, namespace="langgraph")
+
+# 2. Build your graph with the checkpoint saver
+def my_node(state: State) -> State:
+    return {"messages": state["messages"], "step": state["step"] + 1}
+
+graph = (
+    StateGraph(State)
+    .add_node("node", my_node)
+    .set_entry_point("node")
+    .add_edge("node", END)
+    .compile(checkpointer=saver)
+)
+
+# 3. Run — checkpoints are persisted automatically
+config = {"configurable": {"thread_id": "my-thread"}}
+result = graph.invoke({"messages": [], "step": 0}, config=config)
+print("Step:", result["step"])  # 1
+
+# Restart your process — graph resumes from the last checkpoint
+result = graph.invoke({"messages": [], "step": result["step"]}, config=config)
+print("Step:", result["step"])  # 2
+```
+
+## How It Works
+
+Each checkpoint is stored as an AgentState object:
+
+| Field | Value |
+|-------|-------|
+| `type` | `"langgraph_checkpoint"` |
+| `id` | `"{thread_id}:{checkpoint_id}"` |
+| `tags` | `{"thread_id": "...", "checkpoint_ns": "..."}` |
+| `body` | `{"checkpoint": {...}, "metadata": {...}}` |
+
+This means you can inspect, query, and time-travel through checkpoints using the standard AgentState API.
+
+## Requirements
+
+- AgentState server running (see [quickstart](https://github.com/ayushmi/agentstate#quick-start))
+- `langgraph >= 0.1.0`
+- `langchain-core >= 0.1.0`

--- a/adapters/python/langgraph_agentstate/langgraph_agentstate/__init__.py
+++ b/adapters/python/langgraph_agentstate/langgraph_agentstate/__init__.py
@@ -1,0 +1,3 @@
+from .checkpoint_saver import AgentStateCheckpointSaver
+
+__all__ = ["AgentStateCheckpointSaver"]

--- a/adapters/python/langgraph_agentstate/langgraph_agentstate/checkpoint_saver.py
+++ b/adapters/python/langgraph_agentstate/langgraph_agentstate/checkpoint_saver.py
@@ -1,0 +1,244 @@
+"""
+LangGraph checkpoint saver backed by AgentState.
+
+Install:
+    pip install langgraph-agentstate
+
+Usage:
+    from agentstate import AgentStateClient
+    from langgraph_agentstate import AgentStateCheckpointSaver
+    from langgraph.graph import StateGraph
+
+    client = AgentStateClient("http://localhost:8080", namespace="default")
+    saver = AgentStateCheckpointSaver(client, namespace="langgraph")
+
+    graph = StateGraph(...).compile(checkpointer=saver)
+    graph.invoke({...}, config={"configurable": {"thread_id": "thread-1"}})
+
+Storage layout per checkpoint:
+    type  = "langgraph_checkpoint"
+    id    = "{thread_id}:{checkpoint_id}"
+    tags  = {"thread_id": <thread_id>, "checkpoint_ns": <checkpoint_ns>}
+    body  = {"checkpoint": <checkpoint dict>, "metadata": <metadata dict>}
+"""
+
+import asyncio
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional
+
+from agentstate import AgentStateClient
+
+try:
+    from langgraph.checkpoint.base import (
+        BaseCheckpointSaver,
+        Checkpoint,
+        CheckpointMetadata,
+        CheckpointTuple,
+        SerializerProtocol,
+    )
+except ImportError as e:
+    raise ImportError(
+        "langgraph is required. Install it with: pip install langgraph"
+    ) from e
+
+try:
+    from langchain_core.runnables import RunnableConfig
+except ImportError as e:
+    raise ImportError(
+        "langchain-core is required. Install it with: pip install langchain-core"
+    ) from e
+
+
+class AgentStateCheckpointSaver(BaseCheckpointSaver):
+    """
+    LangGraph checkpoint saver that persists checkpoints in AgentState.
+
+    Each checkpoint is stored as an AgentState object:
+      - type = "langgraph_checkpoint"
+      - id   = "{thread_id}:{checkpoint_id}"  (stable, upserts in place)
+      - tags = {"thread_id": ..., "checkpoint_ns": ...}
+      - body = {"checkpoint": {...}, "metadata": {...}}
+
+    Supports both sync and async LangGraph graph execution.
+    """
+
+    def __init__(self, client: AgentStateClient, namespace: str = "langgraph"):
+        """
+        Args:
+            client: An AgentStateClient instance (base_url and api_key are reused).
+            namespace: AgentState namespace to store checkpoints in.
+        """
+        super().__init__()
+        # Reuse connection settings from the provided client but isolate namespace
+        api_key = client.session.headers.get("Authorization", "").replace("Bearer ", "") or None
+        self._client = AgentStateClient(
+            base_url=client.base_url,
+            namespace=namespace,
+            api_key=api_key if api_key else None,
+        )
+
+    # -------------------------------------------------------------------------
+    # Sync interface (required by BaseCheckpointSaver)
+    # -------------------------------------------------------------------------
+
+    def get_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
+        """Return the latest checkpoint tuple for the given thread, or a specific one by ID."""
+        configurable = config.get("configurable", {})
+        thread_id = configurable.get("thread_id", "")
+        checkpoint_id = configurable.get("checkpoint_id")
+
+        if checkpoint_id:
+            obj_id = f"{thread_id}:{checkpoint_id}"
+            try:
+                obj = self._client.get_agent(obj_id)
+            except Exception:
+                return None
+            return self._to_checkpoint_tuple(obj, config)
+        else:
+            results = self._client.query_agents(tags={"thread_id": thread_id})
+            if not results:
+                return None
+            latest = max(results, key=lambda o: o.get("commit_seq", 0))
+            return self._to_checkpoint_tuple(latest, config)
+
+    def put(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: Dict[str, Any],
+    ) -> RunnableConfig:
+        """Persist a checkpoint and return the updated config containing the checkpoint_id."""
+        configurable = config.get("configurable", {})
+        thread_id = configurable.get("thread_id", "")
+        checkpoint_ns = configurable.get("checkpoint_ns", "")
+        checkpoint_id = checkpoint["id"]
+        obj_id = f"{thread_id}:{checkpoint_id}"
+
+        self._client.create_agent(
+            agent_type="langgraph_checkpoint",
+            body={"checkpoint": checkpoint, "metadata": metadata},
+            tags={"thread_id": thread_id, "checkpoint_ns": checkpoint_ns},
+            agent_id=obj_id,
+            cause={"actor": "langgraph", "note": f"checkpoint {checkpoint_id}"},
+        )
+        return {
+            **config,
+            "configurable": {
+                **configurable,
+                "checkpoint_id": checkpoint_id,
+                "checkpoint_ns": checkpoint_ns,
+            },
+        }
+
+    def put_writes(
+        self,
+        config: RunnableConfig,
+        writes: List[Any],
+        task_id: str,
+    ) -> None:
+        """Store intermediate writes (pending channel values) — stored as a separate object."""
+        configurable = config.get("configurable", {})
+        thread_id = configurable.get("thread_id", "")
+        checkpoint_id = configurable.get("checkpoint_id", "")
+        obj_id = f"{thread_id}:{checkpoint_id}:writes:{task_id}"
+
+        self._client.create_agent(
+            agent_type="langgraph_pending_write",
+            body={"writes": writes, "task_id": task_id},
+            tags={"thread_id": thread_id, "checkpoint_id": checkpoint_id},
+            agent_id=obj_id,
+        )
+
+    def list(
+        self,
+        config: Optional[RunnableConfig],
+        *,
+        filter: Optional[Dict[str, Any]] = None,
+        before: Optional[RunnableConfig] = None,
+        limit: Optional[int] = None,
+    ) -> Iterator[CheckpointTuple]:
+        """Yield checkpoints for a thread, newest first."""
+        if not config:
+            return
+        thread_id = config.get("configurable", {}).get("thread_id", "")
+        results = self._client.query_agents(tags={"thread_id": thread_id})
+        # Only langgraph_checkpoint objects (not pending writes)
+        results = [r for r in results if r.get("type") == "langgraph_checkpoint"]
+        results.sort(key=lambda o: o.get("commit_seq", 0), reverse=True)
+        if limit:
+            results = results[:limit]
+        for obj in results:
+            ct = self._to_checkpoint_tuple(obj, config)
+            if ct:
+                yield ct
+
+    # -------------------------------------------------------------------------
+    # Async interface (delegates to sync via run_in_executor for simplicity)
+    # -------------------------------------------------------------------------
+
+    async def aget_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, self.get_tuple, config)
+
+    async def aput(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: Dict[str, Any],
+    ) -> RunnableConfig:
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, self.put, config, checkpoint, metadata, new_versions)
+
+    async def aput_writes(
+        self,
+        config: RunnableConfig,
+        writes: List[Any],
+        task_id: str,
+    ) -> None:
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(None, self.put_writes, config, writes, task_id)
+
+    async def alist(
+        self,
+        config: Optional[RunnableConfig],
+        *,
+        filter: Optional[Dict[str, Any]] = None,
+        before: Optional[RunnableConfig] = None,
+        limit: Optional[int] = None,
+    ) -> AsyncIterator[CheckpointTuple]:
+        loop = asyncio.get_event_loop()
+        items = await loop.run_in_executor(
+            None,
+            lambda: list(self.list(config, filter=filter, before=before, limit=limit)),
+        )
+        for item in items:
+            yield item
+
+    # -------------------------------------------------------------------------
+    # Helpers
+    # -------------------------------------------------------------------------
+
+    def _to_checkpoint_tuple(
+        self, obj: Dict[str, Any], config: RunnableConfig
+    ) -> Optional[CheckpointTuple]:
+        body = obj.get("body", {})
+        checkpoint = body.get("checkpoint")
+        metadata = body.get("metadata", {})
+        if not checkpoint:
+            return None
+        tags = obj.get("tags", {})
+        thread_id = tags.get("thread_id", "")
+        checkpoint_id = checkpoint.get("id", "")
+        return CheckpointTuple(
+            config={
+                "configurable": {
+                    "thread_id": thread_id,
+                    "checkpoint_id": checkpoint_id,
+                    "checkpoint_ns": tags.get("checkpoint_ns", ""),
+                }
+            },
+            checkpoint=checkpoint,
+            metadata=metadata,
+            parent_config=None,
+        )

--- a/adapters/python/langgraph_agentstate/pyproject.toml
+++ b/adapters/python/langgraph_agentstate/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.backends.legacy:build"
+
+[project]
+name = "langgraph-agentstate"
+version = "0.1.0"
+description = "LangGraph checkpoint saver backed by AgentState"
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = [
+    "agentstate>=1.0.2",
+    "langgraph>=0.1.0",
+    "langchain-core>=0.1.0",
+]
+
+[project.optional-dependencies]
+dev = ["pytest", "pytest-asyncio"]
+
+[project.urls]
+Homepage = "https://github.com/ayushmi/agentstate"

--- a/adapters/python/openai_agentstate/README.md
+++ b/adapters/python/openai_agentstate/README.md
@@ -1,0 +1,67 @@
+# openai-agentstate
+
+Persistent run storage for the [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) backed by [AgentState](https://github.com/ayushmi/agentstate).
+
+Store and retrieve agent runs across restarts. Query by agent name, status, or any custom tag.
+
+## Install
+
+```bash
+pip install openai-agentstate
+```
+
+## Quick Start
+
+```python
+from agentstate import AgentStateClient
+from openai_agentstate import AgentStateStore
+
+client = AgentStateClient("http://localhost:8080", namespace="openai-runs")
+store = AgentStateStore(client)
+
+# Save a run (call this after each run completes)
+store.save_run("run_abc123", {
+    "agent_name": "research-agent",
+    "status": "completed",
+    "input": "What is the capital of France?",
+    "output": "Paris",
+    "model": "gpt-4o",
+})
+
+# Retrieve a specific run
+run = store.get_run("run_abc123")
+print(run["output"])  # "Paris"
+
+# List all completed runs for an agent
+runs = store.list_runs(agent_name="research-agent", status="completed")
+print(f"Found {len(runs)} completed runs")
+
+# Attach to OpenAI Agents SDK Runner (when run_storage interface is stable)
+# from openai_agents import Runner
+# runner = Runner(agent=my_agent, run_storage=store)
+```
+
+## Storage Layout
+
+Each run is stored as an AgentState object:
+
+| Field | Value |
+|-------|-------|
+| `type` | `"openai_run"` |
+| `id` | the `run_id` you provide |
+| `tags` | `{"status": "...", "agent_name": "..."}` |
+| `body` | the full `run_data` dict |
+
+## API
+
+### `save_run(run_id, run_data)` → `dict`
+Persist a run. Idempotent — calling twice with the same `run_id` updates in place.
+
+### `get_run(run_id)` → `dict | None`
+Retrieve the `run_data` for a run by ID. Returns `None` if not found.
+
+### `list_runs(agent_name?, status?, limit?)` → `list[dict]`
+List runs, optionally filtered. Returns the `run_data` bodies.
+
+### `delete_run(run_id)` → `None`
+Delete a run by ID.

--- a/adapters/python/openai_agentstate/openai_agentstate/__init__.py
+++ b/adapters/python/openai_agentstate/openai_agentstate/__init__.py
@@ -1,0 +1,3 @@
+from .store import AgentStateStore
+
+__all__ = ["AgentStateStore"]

--- a/adapters/python/openai_agentstate/openai_agentstate/store.py
+++ b/adapters/python/openai_agentstate/openai_agentstate/store.py
@@ -1,0 +1,136 @@
+"""
+AgentState storage adapter for the OpenAI Agents SDK.
+
+Stores agent runs as AgentState objects so they can be retrieved, listed,
+and audited across process restarts.
+
+Install:
+    pip install openai-agentstate
+
+Usage:
+    from agentstate import AgentStateClient
+    from openai_agentstate import AgentStateStore
+
+    client = AgentStateClient("http://localhost:8080", namespace="openai-runs")
+    store = AgentStateStore(client)
+
+    # Save a run
+    store.save_run("run_abc123", {"status": "completed", "output": "Paris"})
+
+    # Retrieve it later
+    run = store.get_run("run_abc123")
+
+    # List all completed runs for an agent
+    runs = store.list_runs(agent_name="research-agent", status="completed")
+
+Storage layout per run:
+    type = "openai_run"
+    id   = run_id
+    tags = {"status": <status>, "agent_name": <agent_name>}  (populated from run_data)
+    body = run_data (the full run dict as-is)
+"""
+
+from typing import Any, Dict, List, Optional
+
+from agentstate import AgentStateClient
+
+
+class AgentStateStore:
+    """
+    Run storage backend for the OpenAI Agents SDK backed by AgentState.
+
+    This class is intentionally duck-typed (not inheriting from a base class)
+    so it remains compatible across OpenAI SDK versions as the interface evolves.
+
+    Attach it to a Runner:
+        runner = Runner(agent=my_agent, run_storage=AgentStateStore(client))
+    """
+
+    def __init__(self, client: AgentStateClient):
+        """
+        Args:
+            client: AgentStateClient connected to your AgentState server.
+                    The client's namespace is used for all run storage.
+        """
+        self._client = client
+
+    def save_run(self, run_id: str, run_data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Persist a run. Calling this twice with the same run_id updates in place.
+
+        Args:
+            run_id:   Unique run identifier (e.g., from OpenAI's run object).
+            run_data: The full run dict to persist (any JSON-serializable structure).
+
+        Returns:
+            The AgentState object representing the stored run.
+        """
+        tags: Dict[str, str] = {}
+        status = run_data.get("status")
+        if status is not None:
+            tags["status"] = str(status)
+
+        agent_name = (
+            run_data.get("agent_name")
+            or (run_data.get("agent") or {}).get("name")
+        )
+        if agent_name:
+            tags["agent_name"] = str(agent_name)
+
+        return self._client.create_agent(
+            agent_type="openai_run",
+            body=run_data,
+            tags=tags,
+            agent_id=run_id,
+            cause={"actor": "openai-agents-sdk", "note": f"run {run_id} status={status}"},
+        )
+
+    def get_run(self, run_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Retrieve the body of a single run by ID.
+
+        Returns:
+            The run_data dict that was passed to save_run(), or None if not found.
+        """
+        try:
+            obj = self._client.get_agent(run_id)
+            return obj.get("body")
+        except Exception:
+            return None
+
+    def list_runs(
+        self,
+        agent_name: Optional[str] = None,
+        status: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        List stored runs, optionally filtered by agent name and/or status.
+
+        Args:
+            agent_name: Only return runs for this agent.
+            status:     Only return runs with this status (e.g., "completed", "failed").
+            limit:      Maximum number of runs to return.
+
+        Returns:
+            List of run_data dicts (the bodies, not the AgentState wrappers).
+        """
+        tags: Dict[str, str] = {}
+        if agent_name:
+            tags["agent_name"] = agent_name
+        if status:
+            tags["status"] = status
+
+        results = self._client.query_agents(tags=tags if tags else None)
+        if limit:
+            results = results[:limit]
+        return [r.get("body", {}) for r in results]
+
+    def delete_run(self, run_id: str) -> None:
+        """
+        Delete a run by ID.
+
+        Args:
+            run_id: Unique run identifier to delete.
+        """
+        self._client.delete_agent(run_id)

--- a/adapters/python/openai_agentstate/pyproject.toml
+++ b/adapters/python/openai_agentstate/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.backends.legacy:build"
+
+[project]
+name = "openai-agentstate"
+version = "0.1.0"
+description = "OpenAI Agents SDK run storage adapter backed by AgentState"
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = [
+    "agentstate>=1.0.2",
+]
+
+[project.optional-dependencies]
+sdk = ["openai-agents>=0.1.0"]
+
+[project.urls]
+Homepage = "https://github.com/ayushmi/agentstate"

--- a/crates/agentstate-cli/Cargo.toml
+++ b/crates/agentstate-cli/Cargo.toml
@@ -10,4 +10,5 @@ serde_json = { workspace = true }
 zstd = { workspace = true }
 anyhow = { workspace = true }
 agentstate-storage = { path = "../agentstate-storage" }
+agentstate-verify = { path = "../agentstate-verify" }
 ciborium = { workspace = true }

--- a/crates/agentstate-cli/src/main.rs
+++ b/crates/agentstate-cli/src/main.rs
@@ -1,7 +1,7 @@
 use agentstate_storage::walbin;
+use agentstate_verify;
 use anyhow::Result;
 use clap::{Parser, Subcommand};
-use agentstate_verify;
 
 #[derive(Parser)]
 #[command(name = "agentstate")]
@@ -111,7 +111,13 @@ fn main() -> Result<()> {
             let report = serde_json::json!({ "last_seq": last_seq, "objects": objs.len(), "crc_ok": true, "index_consistent": true });
             std::fs::write(out, serde_json::to_vec_pretty(&report)?)?;
         }
-        Cmd::Verify { dir, ns, property, output, fail_on_violation } => {
+        Cmd::Verify {
+            dir,
+            ns,
+            property,
+            output,
+            fail_on_violation,
+        } => {
             if property.is_empty() {
                 eprintln!("No property files specified. Use --property <path.ltl.json>");
                 std::process::exit(2);
@@ -127,14 +133,20 @@ fn main() -> Result<()> {
                 std::process::exit(1);
             }
         }
-        Cmd::Replay { object_id, dir, ns, snapshot } => {
+        Cmd::Replay {
+            object_id,
+            dir,
+            ns,
+            snapshot,
+        } => {
             let mut versions: Vec<serde_json::Value> = Vec::new();
 
             // 1. Seed from snapshot if provided
             if let Some(snap_path) = snapshot {
                 for obj in read_snapshot(&snap_path).unwrap_or_default() {
                     let id_match = obj.get("id").and_then(|v| v.as_str()) == Some(&object_id);
-                    let ns_match = ns.as_deref()
+                    let ns_match = ns
+                        .as_deref()
                         .map(|n| obj.get("ns").and_then(|v| v.as_str()) == Some(n))
                         .unwrap_or(true);
                     if id_match && ns_match {
@@ -175,7 +187,11 @@ fn main() -> Result<()> {
                 std::process::exit(1);
             }
 
-            println!("History for '{}' ({} version(s)):", object_id, versions.len());
+            println!(
+                "History for '{}' ({} version(s)):",
+                object_id,
+                versions.len()
+            );
             println!("{}", "─".repeat(60));
 
             let mut prev_body: Option<serde_json::Value> = None;
@@ -183,11 +199,19 @@ fn main() -> Result<()> {
                 let ts = obj.get("ts").and_then(|v| v.as_str()).unwrap_or("unknown");
                 let seq = obj.get("commit_seq").and_then(|v| v.as_u64()).unwrap_or(0);
 
-                if obj.get("_deleted").and_then(|v| v.as_bool()).unwrap_or(false) {
+                if obj
+                    .get("_deleted")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false)
+                {
                     println!("[v{}] ts={} DELETED", i + 1, ts);
                 } else {
                     let commit = obj.get("commit").and_then(|v| v.as_str()).unwrap_or("?");
-                    let short_commit = if commit.len() >= 8 { &commit[..8] } else { commit };
+                    let short_commit = if commit.len() >= 8 {
+                        &commit[..8]
+                    } else {
+                        commit
+                    };
                     println!("[v{}] ts={} commit={} seq={}", i + 1, ts, short_commit, seq);
 
                     if let Some(cur) = obj.get("body") {

--- a/crates/agentstate-cli/src/main.rs
+++ b/crates/agentstate-cli/src/main.rs
@@ -19,6 +19,20 @@ enum Cmd {
         #[arg(long)]
         dump: Option<String>,
     },
+    /// Show the full state history of a single object, with field-level diffs between versions.
+    Replay {
+        /// Object ID to trace through the WAL
+        object_id: String,
+        /// WAL directory (same as DATA_DIR used by the server)
+        #[arg(long, short = 'd', default_value = ".")]
+        dir: String,
+        /// Filter to a specific namespace (optional; omit to match any namespace)
+        #[arg(long, short = 'n')]
+        ns: Option<String>,
+        /// Seed initial state from a snapshot file (.zst) before replaying the WAL
+        #[arg(long, short = 's')]
+        snapshot: Option<String>,
+    },
 }
 
 fn read_snapshot(path: &str) -> Result<Vec<serde_json::Value>> {
@@ -77,6 +91,111 @@ fn main() -> Result<()> {
             }
             let report = serde_json::json!({ "last_seq": last_seq, "objects": objs.len(), "crc_ok": true, "index_consistent": true });
             std::fs::write(out, serde_json::to_vec_pretty(&report)?)?;
+        }
+        Cmd::Replay { object_id, dir, ns, snapshot } => {
+            let mut versions: Vec<serde_json::Value> = Vec::new();
+
+            // 1. Seed from snapshot if provided
+            if let Some(snap_path) = snapshot {
+                for obj in read_snapshot(&snap_path).unwrap_or_default() {
+                    let id_match = obj.get("id").and_then(|v| v.as_str()) == Some(&object_id);
+                    let ns_match = ns.as_deref()
+                        .map(|n| obj.get("ns").and_then(|v| v.as_str()) == Some(n))
+                        .unwrap_or(true);
+                    if id_match && ns_match {
+                        versions.push(obj);
+                    }
+                }
+            }
+
+            // 2. Replay WAL
+            let recs = walbin::replay(&dir).unwrap_or_default();
+            for r in recs {
+                match r {
+                    walbin::RecBody::Put { ns: rec_ns, obj } => {
+                        let id_match = obj.get("id").and_then(|v| v.as_str()) == Some(&object_id);
+                        let ns_match = ns.as_deref().map(|n| rec_ns == n).unwrap_or(true);
+                        if id_match && ns_match {
+                            versions.push(obj);
+                        }
+                    }
+                    walbin::RecBody::Delete { ns: rec_ns, id } => {
+                        if id == object_id {
+                            let ns_match = ns.as_deref().map(|n| rec_ns == n).unwrap_or(true);
+                            if ns_match {
+                                versions.push(serde_json::json!({
+                                    "id": id,
+                                    "ns": rec_ns,
+                                    "_deleted": true,
+                                }));
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            if versions.is_empty() {
+                eprintln!("No history found for object '{}'", object_id);
+                std::process::exit(1);
+            }
+
+            println!("History for '{}' ({} version(s)):", object_id, versions.len());
+            println!("{}", "─".repeat(60));
+
+            let mut prev_body: Option<serde_json::Value> = None;
+            for (i, obj) in versions.iter().enumerate() {
+                let ts = obj.get("ts").and_then(|v| v.as_str()).unwrap_or("unknown");
+                let seq = obj.get("commit_seq").and_then(|v| v.as_u64()).unwrap_or(0);
+
+                if obj.get("_deleted").and_then(|v| v.as_bool()).unwrap_or(false) {
+                    println!("[v{}] ts={} DELETED", i + 1, ts);
+                } else {
+                    let commit = obj.get("commit").and_then(|v| v.as_str()).unwrap_or("?");
+                    let short_commit = if commit.len() >= 8 { &commit[..8] } else { commit };
+                    println!("[v{}] ts={} commit={} seq={}", i + 1, ts, short_commit, seq);
+
+                    if let Some(cur) = obj.get("body") {
+                        if let Some(prev) = &prev_body {
+                            let cur_map = cur.as_object();
+                            let prev_map = prev.as_object();
+                            if let (Some(cm), Some(pm)) = (cur_map, prev_map) {
+                                for (k, v) in cm {
+                                    match pm.get(k) {
+                                        Some(pv) if pv == v => {}
+                                        Some(pv) => println!("    ~ {}: {} → {}", k, pv, v),
+                                        None => println!("    + {}: {}", k, v),
+                                    }
+                                }
+                                for k in pm.keys() {
+                                    if !cm.contains_key(k) {
+                                        println!("    - {} (removed)", k);
+                                    }
+                                }
+                            }
+                        } else {
+                            println!("    (initial state)");
+                            if let Ok(pretty) = serde_json::to_string_pretty(cur) {
+                                for line in pretty.lines() {
+                                    println!("    {}", line);
+                                }
+                            }
+                        }
+                        prev_body = Some(cur.clone());
+                    }
+
+                    // Show cause if present
+                    if let Some(cause) = obj.get("cause") {
+                        if let Some(actor) = cause.get("actor").and_then(|v| v.as_str()) {
+                            println!("    cause.actor: {}", actor);
+                        }
+                        if let Some(note) = cause.get("note").and_then(|v| v.as_str()) {
+                            println!("    cause.note: {}", note);
+                        }
+                    }
+                }
+                println!();
+            }
         }
     }
     Ok(())

--- a/crates/agentstate-cli/src/main.rs
+++ b/crates/agentstate-cli/src/main.rs
@@ -1,6 +1,7 @@
 use agentstate_storage::walbin;
 use anyhow::Result;
 use clap::{Parser, Subcommand};
+use agentstate_verify;
 
 #[derive(Parser)]
 #[command(name = "agentstate")]
@@ -18,6 +19,24 @@ enum Cmd {
         out: String,
         #[arg(long)]
         dump: Option<String>,
+    },
+    /// Verify temporal properties (LTL) over a WAL trace and emit a JSON report.
+    Verify {
+        /// WAL directory (same as DATA_DIR used by the server)
+        #[arg(long, short = 'd', default_value = ".")]
+        dir: String,
+        /// Filter to a specific namespace (optional; omit to check all namespaces)
+        #[arg(long, short = 'n')]
+        ns: Option<String>,
+        /// Path to a .ltl.json property file (repeatable)
+        #[arg(long, short = 'p')]
+        property: Vec<String>,
+        /// Write JSON report to this file instead of stdout
+        #[arg(long, short = 'o')]
+        output: Option<String>,
+        /// Exit with code 1 if any property fails
+        #[arg(long)]
+        fail_on_violation: bool,
     },
     /// Show the full state history of a single object, with field-level diffs between versions.
     Replay {
@@ -91,6 +110,22 @@ fn main() -> Result<()> {
             }
             let report = serde_json::json!({ "last_seq": last_seq, "objects": objs.len(), "crc_ok": true, "index_consistent": true });
             std::fs::write(out, serde_json::to_vec_pretty(&report)?)?;
+        }
+        Cmd::Verify { dir, ns, property, output, fail_on_violation } => {
+            if property.is_empty() {
+                eprintln!("No property files specified. Use --property <path.ltl.json>");
+                std::process::exit(2);
+            }
+            let properties = agentstate_verify::load_properties(&property)?;
+            let report = agentstate_verify::run(&dir, ns.as_deref(), &properties);
+            let json = serde_json::to_string_pretty(&report)?;
+            match output {
+                Some(path) => std::fs::write(&path, &json)?,
+                None => println!("{}", json),
+            }
+            if fail_on_violation && report.failed > 0 {
+                std::process::exit(1);
+            }
         }
         Cmd::Replay { object_id, dir, ns, snapshot } => {
             let mut versions: Vec<serde_json::Value> = Vec::new();

--- a/crates/agentstate-core/src/errors.rs
+++ b/crates/agentstate-core/src/errors.rs
@@ -12,6 +12,8 @@ pub enum StateError {
     Invalid(String),
     #[error("internal error: {0}")]
     Internal(String),
+    #[error("invariant violation: {0:?}")]
+    InvariantViolation(Vec<String>),
 }
 
 pub type Result<T> = std::result::Result<T, StateError>;

--- a/crates/agentstate-core/src/invariant.rs
+++ b/crates/agentstate-core/src/invariant.rs
@@ -1,0 +1,182 @@
+use crate::model::Object;
+use serde_json::Value;
+
+/// Check an object against a namespace invariant spec.
+/// Returns Ok(()) if all rules pass, or Err with a list of violation messages.
+///
+/// Spec format:
+/// ```json
+/// { "rules": [
+///   { "field": "body.status", "type": "string" },
+///   { "field": "body.score",  "gte": 0, "lte": 1 },
+///   { "field": "body.name",   "required": true },
+///   { "field": "tags.env",    "one_of": ["prod", "staging"] },
+///   { "field": "body.label",  "regex": "^exact" }
+/// ]}
+/// ```
+///
+/// Field paths: `body.<key>` navigates into the body JSON, `tags.<key>` into tags.
+pub fn check(spec: &Value, obj: &Object) -> Result<(), Vec<String>> {
+    let rules = match spec.get("rules").and_then(|r| r.as_array()) {
+        Some(r) => r,
+        None => return Ok(()),
+    };
+
+    let mut violations = Vec::new();
+
+    for rule in rules {
+        let field = match rule.get("field").and_then(|f| f.as_str()) {
+            Some(f) => f,
+            None => continue,
+        };
+
+        let value = resolve_field(field, obj);
+
+        // required
+        if rule.get("required").and_then(|v| v.as_bool()).unwrap_or(false) {
+            if value.is_none() || value == Some(Value::Null) {
+                violations.push(format!("field '{}' is required but missing or null", field));
+                continue;
+            }
+        }
+
+        let val = match &value {
+            Some(v) if !v.is_null() => v.clone(),
+            _ => continue,
+        };
+
+        // type check
+        if let Some(expected_type) = rule.get("type").and_then(|t| t.as_str()) {
+            let actual_ok = match expected_type {
+                "string" => val.is_string(),
+                "number" => val.is_number(),
+                "bool" | "boolean" => val.is_boolean(),
+                "array" => val.is_array(),
+                "object" => val.is_object(),
+                _ => true,
+            };
+            if !actual_ok {
+                violations.push(format!(
+                    "field '{}' must be of type '{}' but got {}",
+                    field,
+                    expected_type,
+                    json_type_name(&val)
+                ));
+            }
+        }
+
+        // eq
+        if let Some(eq_val) = rule.get("eq") {
+            if &val != eq_val {
+                violations.push(format!("field '{}' must equal {}", field, eq_val));
+            }
+        }
+
+        // one_of
+        if let Some(choices) = rule.get("one_of").and_then(|v| v.as_array()) {
+            if !choices.contains(&val) {
+                violations.push(format!(
+                    "field '{}' must be one of {} but got {}",
+                    field,
+                    serde_json::to_string(choices).unwrap_or_default(),
+                    val
+                ));
+            }
+        }
+
+        // numeric range (gte, lte, gt, lt)
+        if let Some(n) = val.as_f64() {
+            if let Some(gte) = rule.get("gte").and_then(|v| v.as_f64()) {
+                if n < gte {
+                    violations.push(format!("field '{}' must be >= {} but got {}", field, gte, n));
+                }
+            }
+            if let Some(lte) = rule.get("lte").and_then(|v| v.as_f64()) {
+                if n > lte {
+                    violations.push(format!("field '{}' must be <= {} but got {}", field, lte, n));
+                }
+            }
+            if let Some(gt) = rule.get("gt").and_then(|v| v.as_f64()) {
+                if n <= gt {
+                    violations.push(format!("field '{}' must be > {} but got {}", field, gt, n));
+                }
+            }
+            if let Some(lt) = rule.get("lt").and_then(|v| v.as_f64()) {
+                if n >= lt {
+                    violations.push(format!("field '{}' must be < {} but got {}", field, lt, n));
+                }
+            }
+        }
+
+        // regex (literal patterns with optional ^ / $ anchors)
+        if let Some(pattern) = rule.get("regex").and_then(|v| v.as_str()) {
+            if let Some(s) = val.as_str() {
+                match simple_regex_match(pattern, s) {
+                    Ok(false) => violations.push(format!(
+                        "field '{}' value '{}' does not match regex '{}'",
+                        field, s, pattern
+                    )),
+                    Err(e) => violations.push(format!("field '{}' regex error: {}", field, e)),
+                    Ok(true) => {}
+                }
+            }
+        }
+    }
+
+    if violations.is_empty() {
+        Ok(())
+    } else {
+        Err(violations)
+    }
+}
+
+/// Resolve a field path to an owned Value.
+/// Supports "body.<key.nested>" and "tags.<key>".
+fn resolve_field(field: &str, obj: &Object) -> Option<Value> {
+    if let Some(rest) = field.strip_prefix("body.") {
+        let pointer = format!("/{}", rest.replace('.', "/"));
+        obj.body.pointer(&pointer).cloned()
+    } else if let Some(key) = field.strip_prefix("tags.") {
+        obj.tags.0.get(key).map(|s| Value::String(s.clone()))
+    } else {
+        None
+    }
+}
+
+fn json_type_name(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+/// Minimal regex: supports ^ anchor, $ anchor, and literal substrings.
+/// For complex patterns, returns Err with a helpful message.
+fn simple_regex_match(pattern: &str, s: &str) -> Result<bool, String> {
+    let anchored_start = pattern.starts_with('^');
+    let anchored_end = pattern.ends_with('$');
+    let core = pattern.trim_start_matches('^').trim_end_matches('$');
+
+    let has_specials = core
+        .chars()
+        .any(|c| matches!(c, '.' | '+' | '*' | '[' | '(' | ')' | '?' | '{' | '}' | '|' | '\\'));
+
+    if has_specials {
+        return Err(format!(
+            "complex regex '{}' not supported; use literal patterns with ^ and $ anchors only",
+            pattern
+        ));
+    }
+
+    let matched = match (anchored_start, anchored_end) {
+        (true, true) => s == core,
+        (true, false) => s.starts_with(core),
+        (false, true) => s.ends_with(core),
+        (false, false) => s.contains(core),
+    };
+    Ok(matched)
+}

--- a/crates/agentstate-core/src/invariant.rs
+++ b/crates/agentstate-core/src/invariant.rs
@@ -33,7 +33,11 @@ pub fn check(spec: &Value, obj: &Object) -> Result<(), Vec<String>> {
         let value = resolve_field(field, obj);
 
         // required
-        if rule.get("required").and_then(|v| v.as_bool()).unwrap_or(false) {
+        if rule
+            .get("required")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+        {
             if value.is_none() || value == Some(Value::Null) {
                 violations.push(format!("field '{}' is required but missing or null", field));
                 continue;
@@ -88,12 +92,18 @@ pub fn check(spec: &Value, obj: &Object) -> Result<(), Vec<String>> {
         if let Some(n) = val.as_f64() {
             if let Some(gte) = rule.get("gte").and_then(|v| v.as_f64()) {
                 if n < gte {
-                    violations.push(format!("field '{}' must be >= {} but got {}", field, gte, n));
+                    violations.push(format!(
+                        "field '{}' must be >= {} but got {}",
+                        field, gte, n
+                    ));
                 }
             }
             if let Some(lte) = rule.get("lte").and_then(|v| v.as_f64()) {
                 if n > lte {
-                    violations.push(format!("field '{}' must be <= {} but got {}", field, lte, n));
+                    violations.push(format!(
+                        "field '{}' must be <= {} but got {}",
+                        field, lte, n
+                    ));
                 }
             }
             if let Some(gt) = rule.get("gt").and_then(|v| v.as_f64()) {
@@ -161,9 +171,12 @@ fn simple_regex_match(pattern: &str, s: &str) -> Result<bool, String> {
     let anchored_end = pattern.ends_with('$');
     let core = pattern.trim_start_matches('^').trim_end_matches('$');
 
-    let has_specials = core
-        .chars()
-        .any(|c| matches!(c, '.' | '+' | '*' | '[' | '(' | ')' | '?' | '{' | '}' | '|' | '\\'));
+    let has_specials = core.chars().any(|c| {
+        matches!(
+            c,
+            '.' | '+' | '*' | '[' | '(' | ')' | '?' | '{' | '}' | '|' | '\\'
+        )
+    });
 
     if has_specials {
         return Err(format!(

--- a/crates/agentstate-core/src/lib.rs
+++ b/crates/agentstate-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod errors;
+pub mod invariant;
 pub mod model;
 pub mod query;
 pub mod util;

--- a/crates/agentstate-core/src/model.rs
+++ b/crates/agentstate-core/src/model.rs
@@ -18,6 +18,18 @@ pub struct VecField {
     pub dims: usize,
 }
 
+/// Records why a state change happened — who made it, what triggered it, and a human note.
+/// All fields are optional so existing callers need no changes.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Cause {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actor: Option<String>,     // agent ID making this change
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trigger: Option<CommitId>, // commit hash that triggered this change
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,      // human-readable reason
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Object {
     pub id: ObjectId,
@@ -33,6 +45,8 @@ pub struct Object {
     pub commit: CommitId,
     pub ts: DateTime<Utc>,
     pub commit_seq: u64, // monotonic per-namespace
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cause: Option<Cause>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -47,6 +61,8 @@ pub struct PutRequest {
     pub id: Option<ObjectId>,
     #[serde(default)]
     pub parents: Vec<CommitId>,
+    #[serde(default)]
+    pub cause: Option<Cause>,
 }
 
 impl Object {
@@ -67,6 +83,7 @@ impl Object {
             commit,
             ts,
             commit_seq,
+            cause: req.cause,
         }
     }
 }

--- a/crates/agentstate-core/src/model.rs
+++ b/crates/agentstate-core/src/model.rs
@@ -23,11 +23,11 @@ pub struct VecField {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Cause {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub actor: Option<String>,     // agent ID making this change
+    pub actor: Option<String>, // agent ID making this change
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trigger: Option<CommitId>, // commit hash that triggered this change
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub note: Option<String>,      // human-readable reason
+    pub note: Option<String>, // human-readable reason
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -78,7 +78,14 @@ impl Object {
         let ts = Utc::now();
         // Include commit_seq and prev_commit in the hash seed so that any WAL
         // reordering or record replacement is cryptographically detectable.
-        let mut seed = format!("{}:{}:{}:{}:{}", &ns, &id, req.r#type, ts.to_rfc3339(), commit_seq);
+        let mut seed = format!(
+            "{}:{}:{}:{}:{}",
+            &ns,
+            &id,
+            req.r#type,
+            ts.to_rfc3339(),
+            commit_seq
+        );
         if let Some(prev) = prev_commit {
             seed.push(':');
             seed.push_str(prev);

--- a/crates/agentstate-core/src/model.rs
+++ b/crates/agentstate-core/src/model.rs
@@ -43,6 +43,8 @@ pub struct Object {
     #[serde(default)]
     pub parents: Vec<CommitId>,
     pub commit: CommitId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prev_commit: Option<CommitId>, // previous commit hash for tamper-evident chain
     pub ts: DateTime<Utc>,
     pub commit_seq: u64, // monotonic per-namespace
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -66,10 +68,21 @@ pub struct PutRequest {
 }
 
 impl Object {
-    pub fn new_with_seq(ns: Namespace, mut req: PutRequest, commit_seq: u64) -> Self {
+    pub fn new_with_seq(
+        ns: Namespace,
+        mut req: PutRequest,
+        commit_seq: u64,
+        prev_commit: Option<&CommitId>,
+    ) -> Self {
         let id = req.id.take().unwrap_or_else(|| Ulid::new().to_string());
         let ts = Utc::now();
-        let mut seed = format!("{}:{}:{}:{}", &ns, &id, req.r#type, ts.to_rfc3339());
+        // Include commit_seq and prev_commit in the hash seed so that any WAL
+        // reordering or record replacement is cryptographically detectable.
+        let mut seed = format!("{}:{}:{}:{}:{}", &ns, &id, req.r#type, ts.to_rfc3339(), commit_seq);
+        if let Some(prev) = prev_commit {
+            seed.push(':');
+            seed.push_str(prev);
+        }
         seed.push_str(&serde_json::to_string(&req.body).unwrap_or_default());
         let commit = blake3_hex(seed.as_bytes());
         Self {
@@ -81,6 +94,7 @@ impl Object {
             ttl_seconds: req.ttl_seconds,
             parents: req.parents,
             commit,
+            prev_commit: prev_commit.cloned(),
             ts,
             commit_seq,
             cause: req.cause,

--- a/crates/agentstate-server/src/main.rs
+++ b/crates/agentstate-server/src/main.rs
@@ -865,6 +865,11 @@ impl agentstate_v1::agent_state_server::AgentState for AgentStateGrpc {
                 Some(req.id)
             },
             parents: req.parents,
+            cause: req.cause.map(|c| agentstate_core::Cause {
+                actor: if c.actor.is_empty() { None } else { Some(c.actor) },
+                trigger: if c.trigger.is_empty() { None } else { Some(c.trigger) },
+                note: if c.note.is_empty() { None } else { Some(c.note) },
+            }),
         };
         let o = self
             .state
@@ -995,6 +1000,11 @@ fn to_proto_object(o: agentstate_core::Object) -> agentstate_v1::Object {
         parents: o.parents,
         commit: o.commit,
         ts_rfc3339: o.ts.to_rfc3339(),
+        cause: o.cause.map(|c| agentstate_v1::Cause {
+            actor: c.actor.unwrap_or_default(),
+            trigger: c.trigger.unwrap_or_default(),
+            note: c.note.unwrap_or_default(),
+        }),
     }
 }
 

--- a/crates/agentstate-server/src/main.rs
+++ b/crates/agentstate-server/src/main.rs
@@ -1,4 +1,4 @@
-use agentstate_core::{PutRequest, QueryRequest};
+use agentstate_core::{PutRequest, QueryRequest, StateError};
 use agentstate_storage::{InMemoryStore, PersistentStore, Storage};
 use axum::http::StatusCode;
 use axum::{
@@ -164,6 +164,8 @@ async fn main() -> anyhow::Result<()> {
         .route("/admin/trim-wal", post(admin_trim_wal))
         .route("/admin/explain-query", post(admin_explain_query))
         .route("/admin/dump", get(admin_dump))
+        .route("/admin/namespaces/:ns/chain-verify", get(admin_chain_verify))
+        .route("/admin/namespaces/:ns/invariants", post(admin_set_invariant).get(admin_get_invariant))
         .route("/metrics", get(metrics))
         .with_state(state)
         .layer(
@@ -422,6 +424,11 @@ async fn put_objects(
                 OPS_TOTAL.with_label_values(&["put"]).inc();
                 (StatusCode::OK, Json(obj)).into_response()
             }
+            Err(StateError::InvariantViolation(violations)) => (
+                StatusCode::CONFLICT,
+                Json(json!({"error": "invariant_violation", "violations": violations})),
+            )
+                .into_response(),
             Err(e) => (
                 StatusCode::BAD_REQUEST,
                 Json(json!({"error": e.to_string()})),
@@ -664,6 +671,58 @@ async fn admin_dump(State(app): State<AppState>, headers: HeaderMap) -> impl Int
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({"error": e.to_string()}))
         ).into_response(),
+    }
+}
+
+async fn admin_chain_verify(
+    State(app): State<AppState>,
+    Path(ns): Path<String>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    if let Err(resp) = enforce_caps(&headers, "admin://global", "admin") {
+        return resp.into_response();
+    }
+    let breaks = app.store.verify_chain(Some(&ns));
+    let ok = breaks.is_empty();
+    let objects_checked = app.store.all_objects().iter().filter(|o| o.ns == ns).count();
+    (StatusCode::OK, Json(json!({
+        "ok": ok,
+        "namespace": ns,
+        "objects_checked": objects_checked,
+        "breaks": breaks,
+    }))).into_response()
+}
+
+async fn admin_set_invariant(
+    State(app): State<AppState>,
+    Path(ns): Path<String>,
+    headers: HeaderMap,
+    Json(spec): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    if let Err(resp) = enforce_caps(&headers, "admin://global", "admin") {
+        return resp.into_response();
+    }
+    if spec.get("rules").and_then(|r| r.as_array()).is_none() {
+        return (StatusCode::BAD_REQUEST, Json(json!({"error": "spec must have a 'rules' array"}))).into_response();
+    }
+    match app.store.set_namespace_invariant(&ns, spec).await {
+        Ok(stored) => (StatusCode::OK, Json(stored)).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": e.to_string()}))).into_response(),
+    }
+}
+
+async fn admin_get_invariant(
+    State(app): State<AppState>,
+    Path(ns): Path<String>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    if let Err(resp) = enforce_caps(&headers, "admin://global", "admin") {
+        return resp.into_response();
+    }
+    match app.store.get_namespace_invariant(&ns).await {
+        Ok(Some(spec)) => (StatusCode::OK, Json(spec)).into_response(),
+        Ok(None) => (StatusCode::NOT_FOUND, Json(json!({"error": "no invariant set for namespace"}))).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": e.to_string()}))).into_response(),
     }
 }
 

--- a/crates/agentstate-server/src/main.rs
+++ b/crates/agentstate-server/src/main.rs
@@ -9,9 +9,8 @@ use axum::{
     Json, Router,
 };
 use once_cell::sync::Lazy;
-use opentelemetry_sdk;
 use opentelemetry_otlp::WithExportConfig;
-use tracing_subscriber::prelude::*;
+use opentelemetry_sdk;
 use prometheus::{
     Encoder, HistogramVec, IntCounter, IntCounterVec, IntGaugeVec, Registry, TextEncoder,
 };
@@ -20,12 +19,13 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use tower_http::cors::{Any, CorsLayer};
 use tracing::{info, Level};
+use tracing_subscriber::prelude::*;
 mod metrics;
-use metrics::{WATCH_CLIENTS, WATCH_EVENTS_TOTAL, WATCH_RESUMES_TOTAL};
+use axum::body::Bytes;
 use futures::Stream;
 use hmac::{Hmac, Mac};
+use metrics::{WATCH_CLIENTS, WATCH_EVENTS_TOTAL, WATCH_RESUMES_TOTAL};
 use sha2::Sha256;
-use axum::body::Bytes;
 use std::path::Path as StdPath;
 use std::pin::Pin;
 use tonic::{transport::Server as GrpcServer, Request, Response as TonicResponse, Status};
@@ -93,7 +93,7 @@ async fn main() -> anyhow::Result<()> {
         idem: Arc::new(parking_lot::RwLock::new(std::collections::HashMap::new())),
         qps: Arc::new(parking_lot::RwLock::new(std::collections::HashMap::new())),
     };
-    
+
     let store_for_backlog = state.store.clone();
     let sweeper_state = state.clone();
     let snapshot_state = state.clone();
@@ -164,8 +164,14 @@ async fn main() -> anyhow::Result<()> {
         .route("/admin/trim-wal", post(admin_trim_wal))
         .route("/admin/explain-query", post(admin_explain_query))
         .route("/admin/dump", get(admin_dump))
-        .route("/admin/namespaces/:ns/chain-verify", get(admin_chain_verify))
-        .route("/admin/namespaces/:ns/invariants", post(admin_set_invariant).get(admin_get_invariant))
+        .route(
+            "/admin/namespaces/:ns/chain-verify",
+            get(admin_chain_verify),
+        )
+        .route(
+            "/admin/namespaces/:ns/invariants",
+            post(admin_set_invariant).get(admin_get_invariant),
+        )
         .route("/metrics", get(metrics))
         .with_state(state)
         .layer(
@@ -248,9 +254,7 @@ async fn main() -> anyhow::Result<()> {
         })
     };
     let grpc = {
-        let svc = AgentStateGrpc {
-            state: grpc_state,
-        };
+        let svc = AgentStateGrpc { state: grpc_state };
         let mut builder = GrpcServer::builder();
         if use_tls {
             let cert = std::fs::read(std::env::var("TLS_CERT_PATH").unwrap()).expect("read cert");
@@ -669,8 +673,9 @@ async fn admin_dump(State(app): State<AppState>, headers: HeaderMap) -> impl Int
         }
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": e.to_string()}))
-        ).into_response(),
+            Json(json!({"error": e.to_string()})),
+        )
+            .into_response(),
     }
 }
 
@@ -684,13 +689,22 @@ async fn admin_chain_verify(
     }
     let breaks = app.store.verify_chain(Some(&ns));
     let ok = breaks.is_empty();
-    let objects_checked = app.store.all_objects().iter().filter(|o| o.ns == ns).count();
-    (StatusCode::OK, Json(json!({
-        "ok": ok,
-        "namespace": ns,
-        "objects_checked": objects_checked,
-        "breaks": breaks,
-    }))).into_response()
+    let objects_checked = app
+        .store
+        .all_objects()
+        .iter()
+        .filter(|o| o.ns == ns)
+        .count();
+    (
+        StatusCode::OK,
+        Json(json!({
+            "ok": ok,
+            "namespace": ns,
+            "objects_checked": objects_checked,
+            "breaks": breaks,
+        })),
+    )
+        .into_response()
 }
 
 async fn admin_set_invariant(
@@ -703,11 +717,19 @@ async fn admin_set_invariant(
         return resp.into_response();
     }
     if spec.get("rules").and_then(|r| r.as_array()).is_none() {
-        return (StatusCode::BAD_REQUEST, Json(json!({"error": "spec must have a 'rules' array"}))).into_response();
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "spec must have a 'rules' array"})),
+        )
+            .into_response();
     }
     match app.store.set_namespace_invariant(&ns, spec).await {
         Ok(stored) => (StatusCode::OK, Json(stored)).into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": e.to_string()}))).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": e.to_string()})),
+        )
+            .into_response(),
     }
 }
 
@@ -721,8 +743,16 @@ async fn admin_get_invariant(
     }
     match app.store.get_namespace_invariant(&ns).await {
         Ok(Some(spec)) => (StatusCode::OK, Json(spec)).into_response(),
-        Ok(None) => (StatusCode::NOT_FOUND, Json(json!({"error": "no invariant set for namespace"}))).into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": e.to_string()}))).into_response(),
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "no invariant set for namespace"})),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": e.to_string()})),
+        )
+            .into_response(),
     }
 }
 
@@ -925,9 +955,21 @@ impl agentstate_v1::agent_state_server::AgentState for AgentStateGrpc {
             },
             parents: req.parents,
             cause: req.cause.map(|c| agentstate_core::Cause {
-                actor: if c.actor.is_empty() { None } else { Some(c.actor) },
-                trigger: if c.trigger.is_empty() { None } else { Some(c.trigger) },
-                note: if c.note.is_empty() { None } else { Some(c.note) },
+                actor: if c.actor.is_empty() {
+                    None
+                } else {
+                    Some(c.actor)
+                },
+                trigger: if c.trigger.is_empty() {
+                    None
+                } else {
+                    Some(c.trigger)
+                },
+                note: if c.note.is_empty() {
+                    None
+                } else {
+                    Some(c.note)
+                },
             }),
         };
         let o = self
@@ -975,7 +1017,10 @@ impl agentstate_v1::agent_state_server::AgentState for AgentStateGrpc {
                 None
             } else {
                 Some(agentstate_core::JsonPathFilter {
-                    equals: std::collections::BTreeMap::from([("$".to_string(), serde_json::Value::String(req.jsonpath))]),
+                    equals: std::collections::BTreeMap::from([(
+                        "$".to_string(),
+                        serde_json::Value::String(req.jsonpath),
+                    )]),
                 })
             },
             vector: None,

--- a/crates/agentstate-storage/src/mem.rs
+++ b/crates/agentstate-storage/src/mem.rs
@@ -34,6 +34,8 @@ struct Inner {
     // Leases: (ns,key) -> (owner, token, expires)
     leases: HashMap<(String, String), (String, u64, DateTime<Utc>)>,
     idem: HashMap<(String, String), super::traits::IdempotencyRecord>,
+    // Namespace invariants: ns -> predicate spec JSON
+    invariants: HashMap<String, serde_json::Value>,
 }
 
 #[derive(Clone, Default)]
@@ -145,6 +147,47 @@ impl InMemoryStore {
         out
     }
 
+    /// Verify the tamper-evident hash chain for a given namespace (or all namespaces if None).
+    /// Returns a list of chain breaks: (object_id, commit_seq, expected_prev, actual_prev).
+    pub fn verify_chain(&self, ns_filter: Option<&str>) -> Vec<serde_json::Value> {
+        let inner = self.inner.read();
+        let mut breaks = Vec::new();
+        for ((ns, id), versions) in inner.data.iter() {
+            if let Some(f) = ns_filter {
+                if ns != f {
+                    continue;
+                }
+            }
+            let mut sorted = versions.clone();
+            sorted.sort_by_key(|o| o.commit_seq);
+            for i in 1..sorted.len() {
+                let prev = &sorted[i - 1];
+                let cur = &sorted[i];
+                let expected_prev = Some(&prev.commit);
+                if cur.prev_commit.as_ref() != expected_prev {
+                    breaks.push(serde_json::json!({
+                        "ns": ns,
+                        "id": id,
+                        "commit_seq": cur.commit_seq,
+                        "expected_prev": prev.commit,
+                        "actual_prev": cur.prev_commit,
+                    }));
+                }
+            }
+        }
+        breaks
+    }
+
+    pub fn set_invariant(&self, ns: &str, spec: serde_json::Value) {
+        let mut inner = self.inner.write();
+        inner.invariants.insert(ns.to_string(), spec);
+    }
+
+    pub fn get_invariant(&self, ns: &str) -> Option<serde_json::Value> {
+        let inner = self.inner.read();
+        inner.invariants.get(ns).cloned()
+    }
+
     pub fn backlog_map(&self) -> std::collections::HashMap<String, usize> {
         let inner = self.inner.read();
         let mut map: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
@@ -174,7 +217,22 @@ impl Storage for InMemoryStore {
             .and_modify(|c| *c += 1)
             .or_insert(1);
         let commit_seq = *next;
-        let obj = Object::new_with_seq(ns.to_string(), req, commit_seq);
+        // For upserts (req.id is Some), chain prev_commit to the last version.
+        // For new objects (req.id is None), no previous commit exists.
+        let prev_commit = req.id.as_ref().and_then(|id| {
+            inner
+                .data
+                .get(&(ns.to_string(), id.clone()))
+                .and_then(|vs| vs.last())
+                .map(|o| o.commit.clone())
+        });
+        let obj = Object::new_with_seq(ns.to_string(), req, commit_seq, prev_commit.as_ref());
+        // Check namespace invariants before inserting
+        if let Some(spec) = inner.invariants.get(ns) {
+            if let Err(violations) = agentstate_core::invariant::check(spec, &obj) {
+                return Err(agentstate_core::StateError::InvariantViolation(violations));
+            }
+        }
         let key = (obj.ns.clone(), obj.id.clone());
         inner.data.entry(key.clone()).or_default().push(obj.clone());
         // maintain indexes
@@ -602,6 +660,19 @@ impl Storage for InMemoryStore {
             }
         }
         objects
+    }
+
+    fn verify_chain(&self, ns: Option<&str>) -> Vec<serde_json::Value> {
+        InMemoryStore::verify_chain(self, ns)
+    }
+
+    async fn set_namespace_invariant(&self, ns: &str, spec: serde_json::Value) -> agentstate_core::Result<serde_json::Value> {
+        InMemoryStore::set_invariant(self, ns, spec.clone());
+        Ok(spec)
+    }
+
+    async fn get_namespace_invariant(&self, ns: &str) -> agentstate_core::Result<Option<serde_json::Value>> {
+        Ok(InMemoryStore::get_invariant(self, ns))
     }
 
 }

--- a/crates/agentstate-storage/src/mem.rs
+++ b/crates/agentstate-storage/src/mem.rs
@@ -457,7 +457,7 @@ impl Storage for InMemoryStore {
     async fn sweep_expired(&self, _retention_secs: u64) -> Result<u64> {
         let now = Utc::now();
         let mut objects_to_cleanup = Vec::new();
-        
+
         // First pass: identify and remove expired objects
         {
             let mut inner = self.inner.write();
@@ -479,13 +479,13 @@ impl Storage for InMemoryStore {
                 }
             }
         } // inner lock is dropped here
-        
+
         // Second pass: cleanup indexes (can be async)
         let removed = objects_to_cleanup.len() as u64;
         for obj in objects_to_cleanup {
             self.cleanup_indexes_for(&obj).await;
         }
-        
+
         Ok(removed)
     }
 
@@ -632,7 +632,7 @@ impl Storage for InMemoryStore {
     async fn admin_trim_wal(&self, _snapshot_id: &str) -> Result<Vec<String>> {
         Err(StateError::Invalid("not persistent".into()))
     }
-    
+
     fn backlog_map(&self) -> std::collections::HashMap<String, u64> {
         let inner = self.inner.read();
         let mut map: std::collections::HashMap<String, u64> = std::collections::HashMap::new();
@@ -650,7 +650,7 @@ impl Storage for InMemoryStore {
         }
         map
     }
-    
+
     fn all_objects(&self) -> Vec<Object> {
         let inner = self.inner.read();
         let mut objects = Vec::new();
@@ -666,15 +666,21 @@ impl Storage for InMemoryStore {
         InMemoryStore::verify_chain(self, ns)
     }
 
-    async fn set_namespace_invariant(&self, ns: &str, spec: serde_json::Value) -> agentstate_core::Result<serde_json::Value> {
+    async fn set_namespace_invariant(
+        &self,
+        ns: &str,
+        spec: serde_json::Value,
+    ) -> agentstate_core::Result<serde_json::Value> {
         InMemoryStore::set_invariant(self, ns, spec.clone());
         Ok(spec)
     }
 
-    async fn get_namespace_invariant(&self, ns: &str) -> agentstate_core::Result<Option<serde_json::Value>> {
+    async fn get_namespace_invariant(
+        &self,
+        ns: &str,
+    ) -> agentstate_core::Result<Option<serde_json::Value>> {
         Ok(InMemoryStore::get_invariant(self, ns))
     }
-
 }
 
 struct MemWatch {

--- a/crates/agentstate-storage/src/persistent.rs
+++ b/crates/agentstate-storage/src/persistent.rs
@@ -281,11 +281,18 @@ impl Storage for PersistentStore {
         self.mem.verify_chain(ns)
     }
 
-    async fn set_namespace_invariant(&self, ns: &str, spec: serde_json::Value) -> Result<serde_json::Value> {
+    async fn set_namespace_invariant(
+        &self,
+        ns: &str,
+        spec: serde_json::Value,
+    ) -> Result<serde_json::Value> {
         self.mem.set_invariant(ns, spec.clone());
         {
             let wal = self.wal.lock().await;
-            let body = RecBody::InvariantSet { ns: ns.to_string(), spec: spec.clone() };
+            let body = RecBody::InvariantSet {
+                ns: ns.to_string(),
+                spec: spec.clone(),
+            };
             wal.append(0, Utc::now().timestamp(), &body)
                 .await
                 .map_err(|e| StateError::Internal(e.to_string()))?;

--- a/crates/agentstate-storage/src/persistent.rs
+++ b/crates/agentstate-storage/src/persistent.rs
@@ -47,6 +47,9 @@ impl PersistentStore {
                 | RecBody::Idempotency { .. } => {
                     // TODO: apply to lease and idempotency stores; left as an exercise for now
                 }
+                RecBody::InvariantSet { ns, spec } => {
+                    mem.set_invariant(&ns, spec);
+                }
             }
         }
         Ok(Self {
@@ -274,6 +277,26 @@ impl Storage for PersistentStore {
         let m = self.manifest.read().clone();
         Ok(serde_json::to_value(m).unwrap())
     }
+    fn verify_chain(&self, ns: Option<&str>) -> Vec<serde_json::Value> {
+        self.mem.verify_chain(ns)
+    }
+
+    async fn set_namespace_invariant(&self, ns: &str, spec: serde_json::Value) -> Result<serde_json::Value> {
+        self.mem.set_invariant(ns, spec.clone());
+        {
+            let wal = self.wal.lock().await;
+            let body = RecBody::InvariantSet { ns: ns.to_string(), spec: spec.clone() };
+            wal.append(0, Utc::now().timestamp(), &body)
+                .await
+                .map_err(|e| StateError::Internal(e.to_string()))?;
+        }
+        Ok(spec)
+    }
+
+    async fn get_namespace_invariant(&self, ns: &str) -> Result<Option<serde_json::Value>> {
+        Ok(self.mem.get_invariant(ns))
+    }
+
     async fn admin_trim_wal(&self, snapshot_id: &str) -> Result<Vec<String>> {
         let mut m = self.manifest.write();
         if m.current_snapshot.as_deref() != Some(snapshot_id) {

--- a/crates/agentstate-storage/src/traits.rs
+++ b/crates/agentstate-storage/src/traits.rs
@@ -81,6 +81,19 @@ pub trait Storage: Send + Sync + 'static {
         Vec::new()
     }
 
+    // Verify hash chain integrity. Returns chain breaks as JSON values.
+    fn verify_chain(&self, _ns: Option<&str>) -> Vec<serde_json::Value> {
+        Vec::new()
+    }
+
+    // Namespace invariant management
+    async fn set_namespace_invariant(&self, _ns: &str, _spec: serde_json::Value) -> Result<serde_json::Value> {
+        Err(agentstate_core::StateError::Internal("not supported".into()))
+    }
+    async fn get_namespace_invariant(&self, _ns: &str) -> Result<Option<serde_json::Value>> {
+        Ok(None)
+    }
+
 }
 
 pub trait WatchHandle: Send {

--- a/crates/agentstate-storage/src/traits.rs
+++ b/crates/agentstate-storage/src/traits.rs
@@ -70,12 +70,12 @@ pub trait Storage: Send + Sync + 'static {
     async fn admin_snapshot(&self) -> Result<(String, u64)>;
     async fn admin_manifest(&self) -> Result<serde_json::Value>;
     async fn admin_trim_wal(&self, snapshot_id: &str) -> Result<Vec<String>>;
-    
+
     // Backlog monitoring
     fn backlog_map(&self) -> std::collections::HashMap<String, u64> {
         Default::default()
     }
-    
+
     // Export all objects (for admin dump)
     fn all_objects(&self) -> Vec<Object> {
         Vec::new()
@@ -87,13 +87,18 @@ pub trait Storage: Send + Sync + 'static {
     }
 
     // Namespace invariant management
-    async fn set_namespace_invariant(&self, _ns: &str, _spec: serde_json::Value) -> Result<serde_json::Value> {
-        Err(agentstate_core::StateError::Internal("not supported".into()))
+    async fn set_namespace_invariant(
+        &self,
+        _ns: &str,
+        _spec: serde_json::Value,
+    ) -> Result<serde_json::Value> {
+        Err(agentstate_core::StateError::Internal(
+            "not supported".into(),
+        ))
     }
     async fn get_namespace_invariant(&self, _ns: &str) -> Result<Option<serde_json::Value>> {
         Ok(None)
     }
-
 }
 
 pub trait WatchHandle: Send {

--- a/crates/agentstate-storage/src/walbin.rs
+++ b/crates/agentstate-storage/src/walbin.rs
@@ -25,6 +25,7 @@ pub enum RecType {
     LeaseRenew = 4,
     LeaseRelease = 5,
     Idempotency = 6,
+    InvariantSet = 7,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -62,6 +63,10 @@ pub enum RecBody {
         key: String,
         response: serde_json::Value,
         expires_ts: i64,
+    },
+    InvariantSet {
+        ns: String,
+        spec: serde_json::Value,
     },
 }
 
@@ -254,6 +259,7 @@ impl WalWriter {
             RecBody::LeaseRenew { .. } => RecType::LeaseRenew,
             RecBody::LeaseRelease { .. } => RecType::LeaseRelease,
             RecBody::Idempotency { .. } => RecType::Idempotency,
+            RecBody::InvariantSet { .. } => RecType::InvariantSet,
         }
     }
 }

--- a/crates/agentstate-verify/Cargo.toml
+++ b/crates/agentstate-verify/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "agentstate-verify"
+version = "0.1.0"
+edition = "2021"
+description = "Temporal property checker for AgentState WAL traces"
+
+[dependencies]
+agentstate-core = { path = "../agentstate-core" }
+agentstate-storage = { path = "../agentstate-storage" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/agentstate-verify/src/lib.rs
+++ b/crates/agentstate-verify/src/lib.rs
@@ -1,5 +1,5 @@
-pub mod predicate;
 pub mod ltl;
+pub mod predicate;
 
 use agentstate_core::Object;
 use agentstate_storage::walbin;
@@ -86,7 +86,10 @@ pub fn load_properties(paths: &[String]) -> anyhow::Result<Vec<Property>> {
 }
 
 /// Replay a WAL directory into a version map: (ns, id) -> Vec<Object> sorted by commit_seq.
-pub fn replay_wal(wal_dir: &str, ns_filter: Option<&str>) -> HashMap<(String, String), Vec<Object>> {
+pub fn replay_wal(
+    wal_dir: &str,
+    ns_filter: Option<&str>,
+) -> HashMap<(String, String), Vec<Object>> {
     let recs = walbin::replay(wal_dir).unwrap_or_default();
     let mut map: HashMap<(String, String), Vec<Object>> = HashMap::new();
 
@@ -124,7 +127,11 @@ pub fn run(wal_dir: &str, ns_filter: Option<&str>, properties: &[Property]) -> V
             // Apply forall selector
             if let Some(selector) = &prop.forall {
                 if let Some(type_filter) = selector.get("type").and_then(|v| v.as_str()) {
-                    if !versions.first().map(|o| o.r#type == type_filter).unwrap_or(false) {
+                    if !versions
+                        .first()
+                        .map(|o| o.r#type == type_filter)
+                        .unwrap_or(false)
+                    {
                         continue;
                     }
                 }

--- a/crates/agentstate-verify/src/lib.rs
+++ b/crates/agentstate-verify/src/lib.rs
@@ -1,0 +1,167 @@
+pub mod predicate;
+pub mod ltl;
+
+use agentstate_core::Object;
+use agentstate_storage::walbin;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::path::Path;
+
+/// A property to verify, loaded from a `.ltl.json` file.
+///
+/// Example:
+/// ```json
+/// {
+///   "name": "status_never_unknown",
+///   "kind": "safety",
+///   "description": "body.status must never equal 'unknown'",
+///   "forall": { "type": "agent" },
+///   "always": { "not": { "field": "body.status", "eq": "unknown" } }
+/// }
+/// ```
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Property {
+    pub name: String,
+    #[serde(default = "default_kind")]
+    pub kind: String, // "safety" or "liveness"
+    #[serde(default)]
+    pub description: String,
+    /// Filter: only check objects matching this selector.
+    /// Supports { "type": "<type>" } or {} for all.
+    #[serde(default)]
+    pub forall: Option<Value>,
+    /// Temporal formula — one of: always, eventually, leads_to, until, not, and, or
+    #[serde(flatten)]
+    pub formula: Value,
+}
+
+fn default_kind() -> String {
+    "safety".into()
+}
+
+/// A single violation found during verification.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Violation {
+    pub object_id: String,
+    pub namespace: String,
+    pub commit_seq: u64,
+    pub ts: String,
+    pub counterexample: Value,
+}
+
+/// Result for a single property.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PropertyResult {
+    pub property: String,
+    pub kind: String,
+    pub passed: bool,
+    pub violations: Vec<Violation>,
+}
+
+/// Full verification report.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct VerifyReport {
+    pub generated_at: String,
+    pub wal_dir: String,
+    pub namespace: Option<String>,
+    pub properties_checked: usize,
+    pub passed: usize,
+    pub failed: usize,
+    pub results: Vec<PropertyResult>,
+}
+
+/// Load properties from a list of `.ltl.json` file paths.
+pub fn load_properties(paths: &[String]) -> anyhow::Result<Vec<Property>> {
+    let mut props = Vec::new();
+    for path in paths {
+        let text = std::fs::read_to_string(path)
+            .map_err(|e| anyhow::anyhow!("cannot read property file '{}': {}", path, e))?;
+        let prop: Property = serde_json::from_str(&text)
+            .map_err(|e| anyhow::anyhow!("cannot parse property file '{}': {}", path, e))?;
+        props.push(prop);
+    }
+    Ok(props)
+}
+
+/// Replay a WAL directory into a version map: (ns, id) -> Vec<Object> sorted by commit_seq.
+pub fn replay_wal(wal_dir: &str, ns_filter: Option<&str>) -> HashMap<(String, String), Vec<Object>> {
+    let recs = walbin::replay(wal_dir).unwrap_or_default();
+    let mut map: HashMap<(String, String), Vec<Object>> = HashMap::new();
+
+    for rec in recs {
+        if let walbin::RecBody::Put { ns, obj } = rec {
+            if let Some(filter) = ns_filter {
+                if ns != filter {
+                    continue;
+                }
+            }
+            if let Ok(o) = serde_json::from_value::<Object>(obj) {
+                map.entry((o.ns.clone(), o.id.clone())).or_default().push(o);
+            }
+        }
+    }
+
+    // Sort each version list by commit_seq
+    for versions in map.values_mut() {
+        versions.sort_by_key(|o| o.commit_seq);
+    }
+
+    map
+}
+
+/// Run verification: replay WAL, check each property against matching objects.
+pub fn run(wal_dir: &str, ns_filter: Option<&str>, properties: &[Property]) -> VerifyReport {
+    let version_map = replay_wal(wal_dir, ns_filter);
+    let mut results = Vec::new();
+    let mut passed_count = 0;
+
+    for prop in properties {
+        let mut violations = Vec::new();
+
+        for ((ns, _id), versions) in &version_map {
+            // Apply forall selector
+            if let Some(selector) = &prop.forall {
+                if let Some(type_filter) = selector.get("type").and_then(|v| v.as_str()) {
+                    if !versions.first().map(|o| o.r#type == type_filter).unwrap_or(false) {
+                        continue;
+                    }
+                }
+                if let Some(ns_filter_val) = selector.get("ns").and_then(|v| v.as_str()) {
+                    if ns != ns_filter_val {
+                        continue;
+                    }
+                }
+            }
+
+            // Evaluate the temporal formula over the version sequence
+            if let Some(v) = ltl::evaluate(&prop.formula, versions) {
+                violations.push(v);
+            }
+        }
+
+        let passed = violations.is_empty();
+        if passed {
+            passed_count += 1;
+        }
+
+        results.push(PropertyResult {
+            property: prop.name.clone(),
+            kind: prop.kind.clone(),
+            passed,
+            violations,
+        });
+    }
+
+    let failed = results.len() - passed_count;
+    VerifyReport {
+        generated_at: Utc::now().to_rfc3339(),
+        wal_dir: wal_dir.to_string(),
+        namespace: ns_filter.map(String::from),
+        properties_checked: properties.len(),
+        passed: passed_count,
+        failed,
+        results,
+    }
+}

--- a/crates/agentstate-verify/src/ltl.rs
+++ b/crates/agentstate-verify/src/ltl.rs
@@ -9,7 +9,6 @@
 ///   and/or:      conjunction/disjunction of multiple formulas
 ///
 /// State predicates (leaf nodes) are handled by `predicate::eval`.
-
 use crate::{predicate, Violation};
 use agentstate_core::Object;
 use serde_json::Value;

--- a/crates/agentstate-verify/src/ltl.rs
+++ b/crates/agentstate-verify/src/ltl.rs
@@ -1,0 +1,170 @@
+/// LTL-style temporal formula evaluator over an ordered sequence of Object versions.
+///
+/// Supported operators (top-level keys in the property JSON):
+///   always:      pred holds at every version
+///   eventually:  pred holds at some version
+///   leads_to:    { "if": pred_a, "then": { "eventually": pred_b } }
+///   until:       { "hold": pred_a, "until": pred_b }
+///   not:         negation of another formula
+///   and/or:      conjunction/disjunction of multiple formulas
+///
+/// State predicates (leaf nodes) are handled by `predicate::eval`.
+
+use crate::{predicate, Violation};
+use agentstate_core::Object;
+use serde_json::Value;
+
+/// Evaluate a temporal formula over a version sequence.
+/// Returns Some(Violation) if the formula is violated, None if it holds.
+pub fn evaluate(formula: &Value, versions: &[Object]) -> Option<Violation> {
+    if versions.is_empty() {
+        return None;
+    }
+
+    if let Some(pred) = formula.get("always") {
+        return check_always(pred, versions);
+    }
+    if let Some(pred) = formula.get("eventually") {
+        return check_eventually(pred, versions);
+    }
+    if let Some(leads_to) = formula.get("leads_to") {
+        return check_leads_to(leads_to, versions);
+    }
+    if let Some(until_spec) = formula.get("until") {
+        return check_until(until_spec, versions);
+    }
+    if let Some(inner) = formula.get("not") {
+        // "not formula" — violation if inner formula does NOT violate
+        return if evaluate(inner, versions).is_none() {
+            // inner holds, so "not inner" fails
+            let first = &versions[0];
+            Some(Violation {
+                object_id: first.id.clone(),
+                namespace: first.ns.clone(),
+                commit_seq: first.commit_seq,
+                ts: first.ts.to_rfc3339(),
+                counterexample: serde_json::json!({"reason": "negated formula holds unexpectedly"}),
+            })
+        } else {
+            None
+        };
+    }
+    if let Some(list) = formula.get("and").and_then(|v| v.as_array()) {
+        for sub in list {
+            if let Some(v) = evaluate(sub, versions) {
+                return Some(v);
+            }
+        }
+        return None;
+    }
+    if let Some(list) = formula.get("or").and_then(|v| v.as_array()) {
+        // "or" holds if at least one sub-formula holds (no violation)
+        let all_violated: Vec<_> = list.iter().filter_map(|s| evaluate(s, versions)).collect();
+        return if all_violated.len() == list.len() {
+            all_violated.into_iter().next()
+        } else {
+            None
+        };
+    }
+
+    // Bare predicate (not wrapped in a temporal operator) — evaluate at each version
+    check_always(formula, versions)
+}
+
+/// always: pred must hold at every version. Returns the first violation.
+fn check_always(pred: &Value, versions: &[Object]) -> Option<Violation> {
+    for obj in versions {
+        if !predicate::eval(pred, obj) {
+            return Some(Violation {
+                object_id: obj.id.clone(),
+                namespace: obj.ns.clone(),
+                commit_seq: obj.commit_seq,
+                ts: obj.ts.to_rfc3339(),
+                counterexample: serde_json::to_value(&obj.body).unwrap_or(Value::Null),
+            });
+        }
+    }
+    None
+}
+
+/// eventually: pred must hold at some version. Violation if it never holds.
+fn check_eventually(pred: &Value, versions: &[Object]) -> Option<Violation> {
+    if versions.iter().any(|o| predicate::eval(pred, o)) {
+        return None;
+    }
+    let last = versions.last().unwrap();
+    Some(Violation {
+        object_id: last.id.clone(),
+        namespace: last.ns.clone(),
+        commit_seq: last.commit_seq,
+        ts: last.ts.to_rfc3339(),
+        counterexample: serde_json::json!({
+            "reason": "predicate never became true across all versions",
+            "final_body": last.body,
+        }),
+    })
+}
+
+/// leads_to: { "if": pred_a, "then": { "eventually": pred_b } }
+/// Whenever pred_a holds at version i, pred_b must hold at some version j >= i.
+fn check_leads_to(spec: &Value, versions: &[Object]) -> Option<Violation> {
+    let if_pred = spec.get("if")?;
+    let then_spec = spec.get("then")?;
+    let then_pred = then_spec.get("eventually")?;
+
+    for (i, obj) in versions.iter().enumerate() {
+        if predicate::eval(if_pred, obj) {
+            let suffix = &versions[i..];
+            if !suffix.iter().any(|o| predicate::eval(then_pred, o)) {
+                return Some(Violation {
+                    object_id: obj.id.clone(),
+                    namespace: obj.ns.clone(),
+                    commit_seq: obj.commit_seq,
+                    ts: obj.ts.to_rfc3339(),
+                    counterexample: serde_json::json!({
+                        "reason": "leads_to: antecedent held but consequent never followed",
+                        "antecedent_body": obj.body,
+                    }),
+                });
+            }
+        }
+    }
+    None
+}
+
+/// until: { "hold": pred_a, "until": pred_b }
+/// pred_a must hold continuously until pred_b becomes true.
+fn check_until(spec: &Value, versions: &[Object]) -> Option<Violation> {
+    let hold_pred = spec.get("hold")?;
+    let until_pred = spec.get("until")?;
+
+    for obj in versions {
+        if predicate::eval(until_pred, obj) {
+            return None; // reached the "until" condition; satisfied
+        }
+        if !predicate::eval(hold_pred, obj) {
+            return Some(Violation {
+                object_id: obj.id.clone(),
+                namespace: obj.ns.clone(),
+                commit_seq: obj.commit_seq,
+                ts: obj.ts.to_rfc3339(),
+                counterexample: serde_json::json!({
+                    "reason": "until: hold predicate failed before until predicate was satisfied",
+                    "body": obj.body,
+                }),
+            });
+        }
+    }
+    // pred_b never became true — violation if pred_a was supposed to hold until pred_b
+    let last = versions.last().unwrap();
+    Some(Violation {
+        object_id: last.id.clone(),
+        namespace: last.ns.clone(),
+        commit_seq: last.commit_seq,
+        ts: last.ts.to_rfc3339(),
+        counterexample: serde_json::json!({
+            "reason": "until: the 'until' predicate never became true",
+            "final_body": last.body,
+        }),
+    })
+}

--- a/crates/agentstate-verify/src/predicate.rs
+++ b/crates/agentstate-verify/src/predicate.rs
@@ -1,0 +1,112 @@
+/// State predicate evaluator — reuses the same DSL as the Layer 2 invariant checker.
+/// Returns true if the predicate holds for the given object's JSON representation.
+
+use agentstate_core::Object;
+use serde_json::Value;
+
+/// Evaluate a state predicate against an object.
+/// Predicate is a JSON object; the same syntax as the invariant `rules` entries but without
+/// the surrounding array — a single rule object here.
+///
+/// Examples:
+///   `{ "field": "body.status", "eq": "active" }`
+///   `{ "not": { "field": "body.status", "eq": "unknown" } }`
+///   `{ "and": [ { "field": "body.score", "gte": 0 }, { "field": "body.score", "lte": 1 } ] }`
+pub fn eval(pred: &Value, obj: &Object) -> bool {
+    // Logical operators
+    if let Some(inner) = pred.get("not") {
+        return !eval(inner, obj);
+    }
+    if let Some(list) = pred.get("and").and_then(|v| v.as_array()) {
+        return list.iter().all(|p| eval(p, obj));
+    }
+    if let Some(list) = pred.get("or").and_then(|v| v.as_array()) {
+        return list.iter().any(|p| eval(p, obj));
+    }
+
+    // Field predicate
+    let field = match pred.get("field").and_then(|f| f.as_str()) {
+        Some(f) => f,
+        None => return true, // no field constraint = vacuously true
+    };
+
+    let val = resolve_field(field, obj);
+
+    // required
+    if pred.get("required").and_then(|v| v.as_bool()).unwrap_or(false) {
+        if val.is_none() || val == Some(Value::Null) {
+            return false;
+        }
+    }
+
+    let v = match val {
+        Some(v) if !v.is_null() => v,
+        _ => return true, // absent, non-required field — predicate doesn't constrain
+    };
+
+    // type
+    if let Some(expected_type) = pred.get("type").and_then(|t| t.as_str()) {
+        let ok = match expected_type {
+            "string" => v.is_string(),
+            "number" => v.is_number(),
+            "bool" | "boolean" => v.is_boolean(),
+            "array" => v.is_array(),
+            "object" => v.is_object(),
+            _ => true,
+        };
+        if !ok {
+            return false;
+        }
+    }
+
+    // eq
+    if let Some(eq_val) = pred.get("eq") {
+        if &v != eq_val {
+            return false;
+        }
+    }
+
+    // one_of
+    if let Some(choices) = pred.get("one_of").and_then(|a| a.as_array()) {
+        if !choices.contains(&v) {
+            return false;
+        }
+    }
+
+    // numeric range
+    if let Some(n) = v.as_f64() {
+        if let Some(gte) = pred.get("gte").and_then(|x| x.as_f64()) {
+            if n < gte {
+                return false;
+            }
+        }
+        if let Some(lte) = pred.get("lte").and_then(|x| x.as_f64()) {
+            if n > lte {
+                return false;
+            }
+        }
+        if let Some(gt) = pred.get("gt").and_then(|x| x.as_f64()) {
+            if n <= gt {
+                return false;
+            }
+        }
+        if let Some(lt) = pred.get("lt").and_then(|x| x.as_f64()) {
+            if n >= lt {
+                return false;
+            }
+        }
+    }
+
+    true
+}
+
+fn resolve_field(field: &str, obj: &Object) -> Option<Value> {
+    if let Some(rest) = field.strip_prefix("body.") {
+        let pointer = format!("/{}", rest.replace('.', "/"));
+        obj.body.pointer(&pointer).cloned()
+    } else if let Some(key) = field.strip_prefix("tags.") {
+        obj.tags.0.get(key).map(|s| Value::String(s.clone()))
+    } else {
+        None
+    }
+}

--- a/crates/agentstate-verify/src/predicate.rs
+++ b/crates/agentstate-verify/src/predicate.rs
@@ -1,6 +1,5 @@
 /// State predicate evaluator — reuses the same DSL as the Layer 2 invariant checker.
 /// Returns true if the predicate holds for the given object's JSON representation.
-
 use agentstate_core::Object;
 use serde_json::Value;
 
@@ -33,7 +32,11 @@ pub fn eval(pred: &Value, obj: &Object) -> bool {
     let val = resolve_field(field, obj);
 
     // required
-    if pred.get("required").and_then(|v| v.as_bool()).unwrap_or(false) {
+    if pred
+        .get("required")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
         if val.is_none() || val == Some(Value::Null) {
             return false;
         }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,87 @@
+# AgentState Roadmap (User-First)
+
+This roadmap prioritizes getting AgentState into users’ hands quickly, then hardens for scale and reliability. Items are grouped by dependency so teams can parallelize safely.
+
+## Principles
+- Self-serve first: frictionless local try, simple hosted path, safe persistence.
+- Clear pricing/on-ramp: free tier + predictable paid ramp via gateway metering.
+- Production-readiness: backups, restore, observability, and perf baselines.
+- Evolve to HA: once adoption is healthy, invest in clustering/consistency.
+
+## Phases (High Level)
+- Phase A — Adoption: Playground + gateway + SDKs + adapters + one‑click deploys
+- Phase B — Hardening: backups/snapshots, benchmarks, SLOs/alerts
+- Phase C — Query/Vector performance: JSONPath engine, materialized indexes, HNSW
+- Phase D — HA/Cluster: per‑namespace Raft, cluster ops, chaos testing (multi‑node)
+- Phase E — Enterprise/Security: Caps v2, Policy DSL, SSO/SAML/SCIM, quotas
+
+## New Work (not yet issues, supports adoption)
+- Playground (static, docs/playground) — DONE (MVP)
+- Hosted Gateway (token issuance + metering + Stripe) — Scaffolding added (gateway/)
+- One‑click deploys: Render/Fly/Cloud Run templates — TODO
+
+## Issue Matrix
+
+| # | Title | Priority | Area | Impact | Effort | Risk | Dependencies | Next Steps |
+|---|-------|----------|------|--------|--------|------|--------------|------------|
+| 26 | Docker images for other platforms than linux/arm64/v8 | P0 | infra | Reduce try friction | S/M | Low | — | Buildx multi‑arch to Docker Hub + GHCR; align README tags |
+| 24 | Enterprise foundations — SSO/SAML/SCIM + quotas/limits | P1 | compliance | Enterprise adoption | L/XL | Med | Gateway identity/usage | Start with OIDC/SAML in gateway; org model; quotas backed by meter |
+| 23 | Benchmarks — YCSB + ANN recall/lat + watch soak | P1 | observability | Perf confidence | M | Med | — | Add YCSB‑style mixes; long watch soak with drop/lag metrics |
+| 22 | Jepsen & chaos CI — partitions, disk-full, crash/recovery | P0 | observability | Durability/consistency | L | High | 17 (backup), 14 (ops) | Begin single‑node crash/disk‑full; nightly chaos; expand to cluster later |
+| 21 | VS Code extension — state browser, live watch, explain | P2 | sdk | Dev UX | M | Low | 10/12 explain | Read‑only browser + watch; link to Playground |
+| 20 | Adapters — LangChain/LangGraph/MCP drop-in memory | P1 | sdk | Framework adoption | M | Low | 10 (query) | Minimal adapters + examples |
+| 19 | Go SDK (full parity) + Java SDK (baseline) | P0 | sdk | Backend adoption | M/L | Med | — | REST client parity with Py/TS; 2 examples per SDK |
+| 18 | Import/Export — Redis/Postgres/Firestore importers; S3/Parquet export | P1 | import-export | Onboarding/portability | M | Med | 17 (export format) | JSONL/Parquet export first; simple import scripts; docs |
+| 17 | Automated snapshots to S3/GCS + lifecycle + PITR to new cluster | P0 | ops | Data safety | M/L | Med | — | Snapshot upload + retention; PITR restore guide + smoke test |
+| 16 | Policy DSL — size/budget/PII/region enforced server-side | P1 | policy | Guardrails | L | Med | 10 (path hooks) | Minimal policy spec compiled to handler checks |
+| 15 | Caps v2 — EdDSA/JWKS + attenuation/delegation | P0 | security | Secure multitenancy | L/XL | Med/High | Gateway, 24 | JWT/EdDSA with JWKS + rotation; compat with HMAC during migration |
+| 14 | Cluster ops — membership, health, rolling upgrades, HA docs | P1 | ops | Operability | L/XL | Med | 13 | Health/readiness, upgrade doc, runbooks |
+| 13 | Per-namespace Raft (CP) — leader-only writes, read index | P0 | cluster | HA writes/consistency | XL | High | 10 (state drivers) | RFC + library choice; write path; read index; 3‑node dev cluster |
+| 12 | Materialized JSONPath indexes & projections — planner integration | P1 | query | Query perf | L | Med | 10 | Index metadata + lifecycle; planner hits; projection pruning |
+| 11 | Vector Index v1 — HNSW (RAM) + lifecycle (READY/BUILDING/STALE) | P0 | vectors | Hybrid retrieval | L | Med | 12 | Embed field, HNSW build/query; async build states; benchmarks |
+| 10 | JSONPath Engine v1 — compiled predicates + planner + explain | P0 | query | Expressive + fast queries | L | Med | — | Compile predicates; plan cache; extend /admin/explain; perf tests |
+| 9 | Hardening pack — SLO alerts, slow-query hints, restore diff UX | P1 | observability | Trust & ops DX | M | Low | 10/12/17 | SLOs + alerts; slow‑query hints; restore diff script |
+| 8 | Delivered — v0.1.0 summary | — | ops | Release hygiene | S | Low | — | Convert to release notes and close |
+| 7 | GA Tracker — v0.1.0 | P0 | ops | Release readiness | S | Low | 23/9/17 | Define GA criteria; checklist; tag + SDK publish |
+
+Notes on dependencies:
+- 12 depends on 10 (planner/compiled predicates). 11 benefits from 12 (hybrid planner).
+- 22 expands after 13/14 for multi‑node chaos, but yields value now for single‑node.
+- 24 (SSO/SCIM/quotas) builds on gateway identity + metering; quotas also leverage token claims.
+- 17 complements 18 for portability + DR.
+- 15 introduces JWT/JWKS while keeping HMAC for transition.
+
+## Prioritized Workstreams (User‑First)
+
+1) Self‑Serve Adoption (Phase A)
+- DONE: Static Playground (docs/playground) for local try.
+- Gateway MVP (gateway/): token issuance + proxy + metering. Add Stripe Checkout/Portal + usage records; persist usage in Redis/Postgres.
+- SDK Expansion: 19 Go SDK (first), Java baseline; 20 Adapters for LangChain/LangGraph/MCP.
+- One‑Click Deploys: Render/Fly/Cloud Run templates; README “Deploy in 1 minute”.
+- Multi‑arch Images: 26 (in progress); ensure Docker Hub and GHCR parity.
+
+2) Safety & Reliability (Phase B)
+- 17 Snapshots to S3/GCS + PITR; nightly smoke restore.
+- 23 Benchmarks (YCSB mix; watch soak); publish baseline in README/docs.
+- 9 Hardening pack: SLOs, alerts, slow‑query hints, restore diff.
+
+3) Query/Vector Performance (Phase C)
+- 10 JSONPath engine v1; 12 Materialized indexes + projections; 11 Vector index v1.
+
+4) HA/Cluster Evolution (Phase D)
+- 13 Per‑namespace Raft; 14 Cluster ops docs/practices; expand 22 to cluster chaos.
+
+5) Enterprise/Security (Phase E)
+- 15 Caps v2 JWT/JWKS + delegation; 16 Policy DSL; 24 SSO/SAML/SCIM + quotas.
+
+## Milestones & Exit Criteria
+
+- M0 (Adoption MVP): Playground + Gateway (token issuance, metering), Go SDK, Adapters, One‑click deploys; multi‑arch images available.
+- M1 (Safe Single‑Node): Snapshots + PITR, Benchmarks published, SLO/alerts, slow‑query hints.
+- M2 (Fast Queries): JSONPath engine + materialized indexes + explain; initial vector index.
+- M3 (HA Preview): 3‑node Raft per‑namespace; cluster ops docs; chaos CI includes multi‑node.
+- M4 (Enterprise Ready): Caps v2, Policy DSL, SSO/SAML/SCIM, org quotas.
+
+---
+
+Last updated: 2025‑08‑25

--- a/docs/blog/2025-08-25-chaos-ci-jepsen-phase1.md
+++ b/docs/blog/2025-08-25-chaos-ci-jepsen-phase1.md
@@ -1,0 +1,60 @@
+In-memory Chaos: Bringing Jepsen-Style CI to a Single-Node Server
+
+18 Aug 2025
+
+I’ve been tightening up durability and availability guarantees for AgentState, and wanted a way to catch the “bad day” bugs before users do: crash loops, disk-full, pauses that look like partitions. We don’t have clustering wired yet, but that shouldn’t block us from doing meaningful chaos. This post is a short field report on how we built a non‑intrusive, repeatable chaos CI that runs against a single node and still finds real issues.
+
+Why do chaos before clustering?
+- Because single-node durability bugs hurt just as much as distributed ones.
+- Because disciplined tests around crash/recovery and ENOSPC shape better storage choices.
+- Because the cheapest time to add observability is before you’re juggling quorum and elections.
+
+Constraints
+- No changes to the server runtime. Prove we can validate from the outside: public HTTP API, SSE watch, Prometheus `/metrics`.
+- Repeatable in CI. No artisanal tmux scripts; it has to run on every PR and nightly.
+- Fast feedback. Minutes, not hours.
+
+The smallest possible harness that matters
+We added a compose overlay that swaps in a Debian runtime image for the server, mounts a 64 MiB tmpfs at `/data`, and gives the container a stable name. That’s all we needed to:
+- Crash: `docker kill` the process, then bring it back up and check durability.
+- Pause: `docker pause` for 5 seconds to simulate a stall/partition surrogate; then unpause and watch clients recover.
+- Disk-full: fill the tmpfs using `fallocate` (or `dd` fallback) so the filesystem hits ENOSPC quickly and predictably.
+
+Workload, not benchmarks
+I didn’t chase microsecond latencies here. The point was correctness under stress. The workload is intentionally simple:
+- Writers continually PUT JSON objects with small updates across a handful of keys.
+- Readers GET random keys. We record the last intended value per key.
+- A watcher opens the SSE endpoint (`/v1/:ns/watch`) and asserts that:
+  - commit sequence ids are monotonically increasing globally;
+  - for a sample of keys, the last seen body on the watch stream matches what writers intended;
+  - the stream doesn’t overflow (server emits an explicit overflow event if it does).
+
+Metrics as tripwires
+If a chaos suite can’t tell you “this is worse,” it’s theatre. We scrape `/metrics` and assert three invariants:
+- `watch_drops_total{reason="overflow"} == 0` — if this trips, we’re losing events.
+- `watch_clients{proto="sse"} >= 1` — sanity check the watcher actually stayed connected during the run.
+- `watch_events_total > 0` — the pipeline is processing events.
+
+Disk-full: directing the pain
+I used a tmpfs so disk pressure is precise and quick. A too‑generous tmpfs wastes CI minutes; too small makes the run flaky. 64 MiB was a sweet spot for us: fill ~56 MiB, watch PUTs start failing, free space, then assert that writes succeed again. The server already returns errors on write failure and recovers cleanly once space is available, which is all we needed at this stage.
+
+Pause and crash: watching the edges
+Pausing the container stalled everything as expected; the SSE client stayed connected after unpause and continued consuming. A hard `SIGKILL` followed by restart required a small reconnect window, but the watcher resumed and caught up without gaps. We specifically validated sequence monotonicity and last‑value agreement after both nemeses.
+
+What we didn’t change (on purpose)
+- We didn’t add special “test hooks” to the server. If chaos needs a custom build, you test the wrong thing.
+- We didn’t overfit to a single metric. Three assertions give us high signal with low noise; more can come later.
+
+What I’d like next
+- Longer soaks with watch streams in nightly, to catch slow back‑pressure mistakes.
+- Label clarity for delete events in `watch_events_total`.
+- A resume counter for SSE (we only count gRPC resumes today) — useful to spot flappy connections.
+- When clustering lands, switch from pause to true partitions and add Jepsen‑style split‑brain workloads.
+
+The payoff
+This chaos CI runs on every PR and nightly. It doesn’t touch the production image, doesn’t require a bespoke environment, and still forces the server through the roughest edges a single node should handle. If a durability bug sneaks in, I want it to fail here loudly, not in a postmortem.
+
+If you’re debating when to add chaos: before clustering is not “too early.” It’s the right time to make correctness visible and routine.
+
+Code
+- PR (harness + CI): https://github.com/ayushmi/agentstate/pull/27

--- a/docs/contributing/new-adapter.md
+++ b/docs/contributing/new-adapter.md
@@ -1,0 +1,227 @@
+# How to Add a New Framework Adapter
+
+Adapters are thin packages that wire a framework's storage interface to AgentState.
+Each adapter lives in `adapters/` and is published as a standalone package so users can
+install only what they need.
+
+**Existing adapters:**
+- `adapters/python/langgraph_agentstate/` — LangGraph checkpoint saver
+- `adapters/python/openai_agentstate/` — OpenAI Agents SDK run storage
+- `adapters/mcp/` — MCP memory server for Claude Desktop and other MCP clients
+
+---
+
+## Directory Convention
+
+```
+adapters/
+  <language>/
+    <framework>_agentstate/
+      <framework>_agentstate/
+        __init__.py        # re-exports the main class
+        adapter.py         # core implementation
+      pyproject.toml       # or package.json / go.mod
+      README.md
+      tests/
+        test_adapter.py
+
+examples/
+  <framework>_example/
+    main.py
+    requirements.txt
+```
+
+---
+
+## Step 1: Understand the Target Interface
+
+Read the framework's docs to find the storage or persistence interface:
+- What base class or protocol must be implemented?
+- Which methods are required vs optional?
+- Are async variants needed?
+
+**Examples of interfaces that map well to AgentState:**
+- LangGraph: `BaseCheckpointSaver` (thread-based, versioned state)
+- OpenAI Agents: `RunStorage` (run_id-keyed records)
+- Haystack: `DocumentStore` (vector + metadata storage)
+- AutoGen: `MessageStore` (conversation history)
+
+---
+
+## Step 2: Map Framework Concepts to AgentState Fields
+
+| Framework concept | AgentState field |
+|------------------|-----------------|
+| Run / thread ID | `id` (stable, upserts in place) |
+| State type / category | `type` (e.g., `"langgraph_checkpoint"`) |
+| State payload | `body` (any JSON) |
+| Filtering dimensions | `tags` (key-value string pairs) |
+| Who made this change | `cause.actor` |
+| Why it changed | `cause.note` |
+| What triggered it | `cause.trigger` (commit hash) |
+
+---
+
+## Step 3: Create the Package
+
+Copy the structure from an existing adapter. Update `pyproject.toml`:
+
+```toml
+[project]
+name = "<framework>-agentstate"
+version = "0.1.0"
+description = "<Framework> adapter backed by AgentState"
+requires-python = ">=3.9"
+dependencies = [
+    "agentstate>=1.0.2",
+    "<framework-package>>=<min-version>",
+]
+```
+
+---
+
+## Step 4: Implement the Adapter
+
+Minimal Python pattern:
+
+```python
+from typing import Any, Dict, List, Optional
+from agentstate import AgentStateClient
+
+
+class AgentStateAdapter:
+    """
+    <Framework> storage adapter backed by AgentState.
+
+    Storage layout:
+      type = "<framework>_state"
+      id   = <framework's stable key>
+      tags = {<filtering dimensions>}
+      body = <framework's state payload>
+    """
+
+    def __init__(self, client: AgentStateClient, namespace: str = "<framework>"):
+        # Isolate into a dedicated namespace so framework state doesn't mix
+        # with other objects in the user's default namespace.
+        api_key = client.session.headers.get("Authorization", "").replace("Bearer ", "") or None
+        self._client = AgentStateClient(
+            base_url=client.base_url,
+            namespace=namespace,
+            api_key=api_key if api_key else None,
+        )
+
+    def save(self, key: str, data: Dict[str, Any], cause: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+        return self._client.create_agent(
+            agent_type="<framework>_state",
+            body=data,
+            agent_id=key,
+            cause=cause,
+        )
+
+    def load(self, key: str) -> Optional[Dict[str, Any]]:
+        try:
+            obj = self._client.get_agent(key)
+            return obj["body"]
+        except Exception:
+            return None
+
+    def list(self, tags: Optional[Dict[str, str]] = None) -> List[Dict[str, Any]]:
+        results = self._client.query_agents(tags=tags)
+        return [r["body"] for r in results]
+
+    def delete(self, key: str) -> None:
+        self._client.delete_agent(key)
+```
+
+---
+
+## Step 5: Write Tests
+
+Minimum test checklist (all must pass against a live AgentState server):
+
+- [ ] `save()` → `load()` round-trip: same key, same data
+- [ ] `save()` twice with same key updates in place (idempotent upsert)
+- [ ] `list()` with tag filter returns only matching items
+- [ ] `delete()` → `load()` returns `None`
+- [ ] Missing key → `load()` returns `None` without raising
+- [ ] Server unreachable → method raises a clear exception (not a hang)
+
+```python
+# tests/test_adapter.py
+import pytest
+from agentstate import AgentStateClient
+from <framework>_agentstate import AgentStateAdapter
+
+
+@pytest.fixture
+def adapter():
+    client = AgentStateClient("http://localhost:8080", namespace="test-<framework>")
+    return AgentStateAdapter(client)
+
+
+def test_round_trip(adapter):
+    adapter.save("key-1", {"value": 42})
+    assert adapter.load("key-1") == {"value": 42}
+
+
+def test_upsert(adapter):
+    adapter.save("key-2", {"value": 1})
+    adapter.save("key-2", {"value": 2})
+    assert adapter.load("key-2") == {"value": 2}
+
+
+def test_missing_key(adapter):
+    assert adapter.load("does-not-exist-xyz") is None
+
+
+def test_delete(adapter):
+    adapter.save("key-3", {"value": 99})
+    adapter.delete("key-3")
+    assert adapter.load("key-3") is None
+```
+
+Run with:
+```bash
+# Start server first
+docker run -p 8080:8080 ayushmi/agentstate:latest
+
+pytest adapters/<language>/<framework>_agentstate/tests/ -v
+```
+
+---
+
+## Step 6: Add an Example
+
+Create `examples/<framework>_example/main.py` showing a realistic scenario — ideally
+one that demonstrates crash recovery or resumption, which is the core value proposition.
+
+The example should be runnable with just:
+```bash
+pip install -r examples/<framework>_example/requirements.txt
+docker run -p 8080:8080 ayushmi/agentstate:latest
+python examples/<framework>_example/main.py
+```
+
+---
+
+## Step 7: Submit a PR
+
+- **Target branch:** `main`
+- **Title:** `feat(adapters): add <framework> adapter`
+- **Required in PR description:**
+  - Link to the framework's storage interface documentation
+  - Screenshot or log output showing the example working end-to-end
+  - Test results output (`pytest -v`)
+
+---
+
+## Reviewer Checklist
+
+- [ ] Package installs cleanly: `pip install -e adapters/<language>/<framework>_agentstate`
+- [ ] All 6 unit tests pass with a live server
+- [ ] Example runs end-to-end without errors
+- [ ] Only `AgentStateClient` public API is used (no internal imports)
+- [ ] `pyproject.toml` pins a minimum version for `agentstate` and the framework
+- [ ] `README.md` includes install instructions, a quick-start snippet, and a storage layout table
+- [ ] New namespace is used (isolated from default user namespace)
+- [ ] `cause` field is populated where meaningful (actor, note)

--- a/docs/playground/index.html
+++ b/docs/playground/index.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AgentState Playground</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="container">
+      <header>
+        <h1>AgentState Playground</h1>
+        <p>Try REST endpoints locally or against a hosted server.</p>
+      </header>
+
+      <section class="config">
+        <h2>Configuration</h2>
+        <div class="row">
+          <label for="baseUrl">Base URL</label>
+          <input id="baseUrl" placeholder="http://localhost:8080" />
+        </div>
+        <div class="row">
+          <label for="namespace">Namespace</label>
+          <input id="namespace" placeholder="my-app" />
+        </div>
+        <div class="row">
+          <label for="token">Bearer Token (optional)</label>
+          <input id="token" placeholder="Paste capability token if required" />
+        </div>
+        <div class="buttons">
+          <button id="saveConfig">Save</button>
+          <button id="loadHosted">Use Hosted (fetch token)</button>
+        </div>
+        <p class="hint">Token not required for local dev unless you enabled caps in compose.</p>
+      </section>
+
+      <section class="actions">
+        <h2>Actions</h2>
+        <div class="grid">
+          <div class="card">
+            <h3>Create / Update Agent</h3>
+            <label>Type</label>
+            <input id="putType" placeholder="chatbot" />
+            <label>Body (JSON)</label>
+            <textarea id="putBody">{
+  "name": "CustomerBot",
+  "status": "active"
+}</textarea>
+            <label>Tags (JSON)</label>
+            <textarea id="putTags">{ "team": "customer-success" }</textarea>
+            <div class="buttons">
+              <button id="doPut">PUT</button>
+            </div>
+          </div>
+
+          <div class="card">
+            <h3>Query Agents</h3>
+            <label>Tags (JSON)</label>
+            <textarea id="queryTags">{ "team": "customer-success" }</textarea>
+            <div class="buttons">
+              <button id="doQuery">Query</button>
+            </div>
+          </div>
+
+          <div class="card">
+            <h3>Get by ID</h3>
+            <label>Agent ID</label>
+            <input id="getId" placeholder="01H..." />
+            <div class="buttons">
+              <button id="doGet">GET</button>
+            </div>
+          </div>
+
+          <div class="card">
+            <h3>Watch (SSE)</h3>
+            <div class="buttons">
+              <button id="startWatch">Start</button>
+              <button id="stopWatch">Stop</button>
+            </div>
+            <pre id="watchOut" class="log"></pre>
+          </div>
+        </div>
+      </section>
+
+      <section class="output">
+        <h2>Output</h2>
+        <pre id="out" class="log"></pre>
+      </section>
+
+      <section class="snippets">
+        <h2>SDK Snippets</h2>
+        <div class="grid">
+          <div class="card">
+            <h3>Python</h3>
+            <pre id="pySnippet" class="code"></pre>
+          </div>
+          <div class="card">
+            <h3>TypeScript</h3>
+            <pre id="tsSnippet" class="code"></pre>
+          </div>
+        </div>
+      </section>
+
+      <footer>
+        <p>
+          Docs: <a href="../quickstart.md">Quickstart</a> •
+          API: <code>/v1/{ns}/objects|query|get</code>
+        </p>
+      </footer>
+    </div>
+
+    <script src="script.js"></script>
+  </body>
+  </html>
+

--- a/docs/playground/script.js
+++ b/docs/playground/script.js
@@ -1,0 +1,152 @@
+(() => {
+  const $ = (id) => document.getElementById(id);
+  const out = $("out");
+  const watchOut = $("watchOut");
+  let es;
+
+  const cfg = {
+    get baseUrl() { return $("baseUrl").value.trim() || "http://localhost:8080"; },
+    get ns() { return $("namespace").value.trim() || "my-app"; },
+    get token() { return $("token").value.trim(); }
+  };
+
+  function saveConfig() {
+    localStorage.setItem("as.baseUrl", cfg.baseUrl);
+    localStorage.setItem("as.ns", cfg.ns);
+    localStorage.setItem("as.token", cfg.token);
+    log("Saved config.");
+    renderSnippets();
+  }
+
+  function loadConfig() {
+    $("baseUrl").value = localStorage.getItem("as.baseUrl") || "http://localhost:8080";
+    $("namespace").value = localStorage.getItem("as.ns") || "my-app";
+    $("token").value = localStorage.getItem("as.token") || "";
+    renderSnippets();
+  }
+
+  function log(msg) {
+    const s = typeof msg === 'string' ? msg : JSON.stringify(msg, null, 2);
+    out.textContent = s;
+  }
+
+  function headers() {
+    const h = { 'Content-Type': 'application/json' };
+    if (cfg.token) h['Authorization'] = `Bearer ${cfg.token}`;
+    return h;
+  }
+
+  async function fetchJSON(url, opts={}) {
+    const res = await fetch(url, opts);
+    const text = await res.text();
+    let body = null;
+    try { body = JSON.parse(text); } catch { body = text; }
+    if (!res.ok) throw { status: res.status, body };
+    return body;
+  }
+
+  async function doPut() {
+    const type = $("putType").value.trim() || "chatbot";
+    let body = {};
+    let tags = {};
+    try { body = JSON.parse($("putBody").value || '{}'); } catch (e) { return log({error: 'Invalid body JSON'}); }
+    try { tags = JSON.parse($("putTags").value || '{}'); } catch (e) { return log({error: 'Invalid tags JSON'}); }
+    try {
+      const resp = await fetchJSON(`${cfg.baseUrl}/v1/${encodeURIComponent(cfg.ns)}/objects`, {
+        method: 'POST',
+        headers: headers(),
+        body: JSON.stringify({ type, body, tags })
+      });
+      log(resp);
+      if (resp && resp.id) { $("getId").value = resp.id; }
+    } catch (e) { log(e); }
+  }
+
+  async function doQuery() {
+    let tags = {};
+    try { tags = JSON.parse($("queryTags").value || '{}'); } catch (e) { return log({error: 'Invalid tags JSON'}); }
+    try {
+      const resp = await fetchJSON(`${cfg.baseUrl}/v1/${encodeURIComponent(cfg.ns)}/query`, {
+        method: 'POST',
+        headers: headers(),
+        body: JSON.stringify({ tags })
+      });
+      log(resp);
+    } catch (e) { log(e); }
+  }
+
+  async function doGet() {
+    const id = $("getId").value.trim();
+    if (!id) return log({error: 'Missing id'});
+    try {
+      const resp = await fetchJSON(`${cfg.baseUrl}/v1/${encodeURIComponent(cfg.ns)}/objects/${encodeURIComponent(id)}`, {
+        headers: headers()
+      });
+      log(resp);
+    } catch (e) { log(e); }
+  }
+
+  function startWatch() {
+    if (es) es.close();
+    watchOut.textContent = '';
+    const url = `${cfg.baseUrl}/v1/${encodeURIComponent(cfg.ns)}/watch`;
+    // EventSource doesn't support headers; if token is needed, advise proxy or gateway.
+    if (cfg.token) {
+      appendWatch({warning: 'SSE cannot set Authorization header. Use a gateway that injects it, or run without caps for dev.'});
+    }
+    es = new EventSource(url);
+    es.onmessage = (ev) => appendWatch({event: 'message', data: safeParse(ev.data)});
+    es.onerror = () => appendWatch({event: 'error'});
+  }
+
+  function stopWatch() {
+    if (es) { es.close(); es = null; appendWatch({event: 'closed'}); }
+  }
+
+  function appendWatch(obj) {
+    const s = typeof obj === 'string' ? obj : JSON.stringify(obj, null, 2);
+    watchOut.textContent += s + "\n";
+    watchOut.scrollTop = watchOut.scrollHeight;
+  }
+
+  function safeParse(s) {
+    try { return JSON.parse(s); } catch { return s; }
+  }
+
+  async function loadHosted() {
+    // Placeholder: expect a hosted gateway exposing /api/token returning { token, baseUrl, namespace }
+    try {
+      const gw = localStorage.getItem('as.gateway') || '';
+      if (!gw) {
+        alert('Set localStorage as.gateway to your hosted gateway URL (e.g., https://play.agentstate.run) and reload.');
+        return;
+      }
+      const resp = await fetch(`${gw}/api/token`, { method: 'POST', credentials: 'include' });
+      const data = await resp.json();
+      if (data.baseUrl) $("baseUrl").value = data.baseUrl;
+      if (data.namespace) $("namespace").value = data.namespace;
+      if (data.token) $("token").value = data.token;
+      saveConfig();
+      log({info: 'Loaded hosted token', ns: data.namespace});
+    } catch (e) {
+      log({error: 'Failed to load hosted token', detail: e});
+    }
+  }
+
+  function renderSnippets() {
+    const py = `from agentstate import AgentStateClient\n\nclient = AgentStateClient(base_url='${cfg.baseUrl}', namespace='${cfg.ns}', api_key='${cfg.token}')\nagent = client.create_agent('chatbot', {'name': 'CustomerBot', 'status': 'active'})\nprint(agent)`;
+    const ts = `import { AgentStateClient } from 'agentstate'\n\nconst client = new AgentStateClient({ baseUrl: '${cfg.baseUrl}', namespace: '${cfg.ns}', apiKey: '${cfg.token}' })\nconst agent = await client.createAgent({ type: 'chatbot', body: { name: 'CustomerBot', status: 'active' } })\nconsole.log(agent)`;
+    $("pySnippet").textContent = py;
+    $("tsSnippet").textContent = ts;
+  }
+
+  $("saveConfig").addEventListener('click', saveConfig);
+  $("loadHosted").addEventListener('click', loadHosted);
+  $("doPut").addEventListener('click', doPut);
+  $("doQuery").addEventListener('click', doQuery);
+  $("doGet").addEventListener('click', doGet);
+  $("startWatch").addEventListener('click', startWatch);
+  $("stopWatch").addEventListener('click', stopWatch);
+  loadConfig();
+})();
+

--- a/docs/playground/styles.css
+++ b/docs/playground/styles.css
@@ -1,0 +1,23 @@
+* { box-sizing: border-box; }
+body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; margin: 0; background: #0b0f14; color: #e6edf3; }
+.container { max-width: 1100px; margin: 0 auto; padding: 24px; }
+header { margin-bottom: 16px; }
+header h1 { margin: 0 0 8px; font-size: 24px; }
+
+.config, .actions, .output, .snippets { background: #0f1720; border: 1px solid #1f2a37; border-radius: 8px; padding: 16px; margin-bottom: 16px; }
+.row { display: grid; grid-template-columns: 160px 1fr; gap: 8px; align-items: center; margin-bottom: 10px; }
+label { color: #9fb3c8; font-size: 14px; }
+input, textarea { width: 100%; background: #0b1220; color: #e6edf3; border: 1px solid #1f2a37; border-radius: 6px; padding: 8px 10px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+textarea { min-height: 120px; }
+.buttons { display: flex; gap: 8px; margin-top: 8px; }
+button { background: #2563eb; color: #fff; border: none; padding: 8px 12px; border-radius: 6px; cursor: pointer; }
+button:hover { background: #1d4ed8; }
+.hint { color: #8ca3b8; font-size: 12px; margin-top: 6px; }
+
+.grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 12px; }
+.card { background: #0c1423; border: 1px solid #1f2a37; border-radius: 8px; padding: 12px; }
+.log, .code { background: #07111d; border: 1px solid #132235; color: #cfe8ff; padding: 12px; border-radius: 6px; overflow: auto; max-height: 380px; }
+
+footer { text-align: center; color: #8ca3b8; font-size: 13px; margin-top: 16px; }
+footer a { color: #8ab4ff; }
+

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -1,0 +1,222 @@
+# AgentState Verifiability System
+
+AgentState includes three layers of formal verifiability that let you **prove** your AI agents behave correctly — not just observe them.
+
+| Layer | What it does | When to use |
+|-------|-------------|-------------|
+| 1. Tamper-evident hash chain | Cryptographically chains every write so WAL tampering is detectable | Always on — zero config |
+| 2. Runtime invariant assertions | JSON predicate rules checked before every write; violations return 409 | Set once per namespace, enforced forever |
+| 3. Temporal property checking | LTL-style properties verified offline over the full WAL trace | In CI/audit pipelines |
+
+---
+
+## Layer 1: Tamper-Evident Hash Chain
+
+Every commit includes `prev_commit` — the blake3 hash of the previous version of the same object. The hash seed includes the `commit_seq`, `prev_commit`, namespace, id, type, timestamp, and body. Reordering or replacing any WAL record breaks the chain.
+
+**Verify via HTTP:**
+```bash
+curl http://localhost:8080/admin/namespaces/production/chain-verify \
+  -H "Authorization: Bearer $AGENTSTATE_API_KEY"
+# → {"ok": true, "namespace": "production", "objects_checked": 142, "breaks": []}
+```
+
+If `ok` is false, `breaks` lists every object and sequence number where the chain is broken.
+
+**What it detects:**
+- WAL record replacement or reordering
+- Snapshot injection (an object whose `prev_commit` doesn't match the WAL predecessor)
+- Manual edits to the data directory
+
+---
+
+## Layer 2: Runtime Invariant Assertions
+
+Set a predicate spec on a namespace; every subsequent `PUT` is validated against it before being stored. A violation returns HTTP 409 with a structured error.
+
+### Set an invariant
+
+```bash
+curl -X POST http://localhost:8080/admin/namespaces/production/invariants \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $AGENTSTATE_API_KEY" \
+  -d '{
+    "rules": [
+      { "field": "body.status", "required": true, "one_of": ["active", "idle", "stopped"] },
+      { "field": "body.score",  "gte": 0, "lte": 1 },
+      { "field": "tags.env",    "required": true }
+    ]
+  }'
+```
+
+### Get the current invariant
+
+```bash
+curl http://localhost:8080/admin/namespaces/production/invariants \
+  -H "Authorization: Bearer $AGENTSTATE_API_KEY"
+```
+
+### Violation response
+
+When a write violates the invariant:
+```json
+HTTP 409 Conflict
+{
+  "error": "invariant_violation",
+  "violations": [
+    "field 'body.status' must be one of [\"active\",\"idle\",\"stopped\"] but got \"unknown\"",
+    "field 'body.score' must be <= 1 but got 1.5"
+  ]
+}
+```
+
+### Predicate DSL reference
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `field` | string | Field path: `body.<key>` or `tags.<key>` (dot-separated for nested) |
+| `required` | bool | Field must be present and non-null |
+| `type` | string | JSON type: `string`, `number`, `bool`, `array`, `object` |
+| `eq` | any | Value must equal this exactly |
+| `one_of` | array | Value must be one of the listed values |
+| `gte`, `lte`, `gt`, `lt` | number | Numeric range checks |
+| `regex` | string | String must match pattern (literal + `^`/`$` anchors) |
+
+### Python SDK
+
+```python
+from agentstate import AgentStateClient
+
+client = AgentStateClient("http://localhost:8080", "production", api_key="...")
+
+# Set invariant
+client.set_invariant("production", [
+    {"field": "body.status", "required": True, "one_of": ["active", "idle", "stopped"]},
+    {"field": "body.score",  "gte": 0, "lte": 1},
+])
+
+# Retrieve invariant
+spec = client.get_invariant("production")
+print(spec)
+
+# Write that violates it → raises HTTPError (409)
+try:
+    client.create_agent("agent", {"status": "unknown", "score": 2.0})
+except Exception as e:
+    print(e)  # invariant_violation: field 'body.status' must be one of ...
+```
+
+### Invariants are durable
+
+Invariant specs are persisted as `InvariantSet` records in the WAL. If the server restarts, they are replayed and re-enforced automatically — no re-configuration needed.
+
+---
+
+## Layer 3: Temporal Property Checking
+
+Verify LTL-style properties over the full WAL execution trace. This is an **offline** operation: point it at a WAL directory and property files, and it outputs a structured JSON report.
+
+### CLI usage
+
+```bash
+agentstate verify \
+  --dir /data/wal \
+  --ns production \
+  --property props/no_unknown_status.ltl.json \
+  --property props/score_eventually_high.ltl.json \
+  --output report.json \
+  --fail-on-violation
+```
+
+Exit code 0 if all properties pass, 1 if any fail (useful in CI).
+
+### Property file format (`.ltl.json`)
+
+```json
+{
+  "name": "status_never_unknown",
+  "kind": "safety",
+  "description": "body.status must never equal 'unknown'",
+  "forall": { "type": "agent" },
+  "always": {
+    "not": { "field": "body.status", "eq": "unknown" }
+  }
+}
+```
+
+**Temporal operators:**
+
+| Operator | JSON key | Meaning |
+|----------|----------|---------|
+| Always | `"always": <pred>` | pred holds at every version of the object |
+| Eventually | `"eventually": <pred>` | pred holds at some version |
+| Leads-to | `"leads_to": {"if": <pred_a>, "then": {"eventually": <pred_b>}}` | whenever A holds, B must follow |
+| Until | `"until": {"hold": <pred_a>, "until": <pred_b>}` | A holds continuously until B |
+| Not | `"not": <formula>` | negation |
+| And/Or | `"and": [...]` / `"or": [...]` | conjunction/disjunction |
+
+**Selector (`forall`):**
+```json
+{ "type": "agent" }          // only check objects of this type
+{ "ns": "production" }       // only this namespace
+{}                            // all objects (default)
+```
+
+### Report format
+
+```json
+{
+  "generated_at": "2026-05-12T10:00:00Z",
+  "wal_dir": "/data/wal",
+  "namespace": "production",
+  "properties_checked": 2,
+  "passed": 1,
+  "failed": 1,
+  "results": [
+    {
+      "property": "status_never_unknown",
+      "kind": "safety",
+      "passed": false,
+      "violations": [
+        {
+          "object_id": "01JX...",
+          "namespace": "production",
+          "commit_seq": 14,
+          "ts": "2026-05-11T08:42:00Z",
+          "counterexample": { "status": "unknown", "score": 0.8 }
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Use in CI
+
+```yaml
+# .github/workflows/verify.yml
+- name: Verify agent behavioral properties
+  run: |
+    agentstate verify \
+      --dir $DATA_DIR \
+      --ns $NAMESPACE \
+      --property props/safety.ltl.json \
+      --output verify-report.json \
+      --fail-on-violation
+- uses: actions/upload-artifact@v4
+  with:
+    name: verify-report
+    path: verify-report.json
+```
+
+---
+
+## EU AI Act Mapping
+
+| Article | Requirement | AgentState mechanism |
+|---------|------------|---------------------|
+| Art. 9 | Risk management system with continuous monitoring | Layer 2 invariants block non-compliant writes in real-time |
+| Art. 13 | Transparency and traceability | `cause` field + `prev_commit` hash chain |
+| Art. 72 | Post-market monitoring, logging | Layer 3 temporal checking over full WAL trace; `chain-verify` endpoint |
+
+The WAL is the audit log. The hash chain makes it tamper-evident. The temporal properties are the formal behavioral specification.

--- a/examples/langgraph_example/requirements.txt
+++ b/examples/langgraph_example/requirements.txt
@@ -1,0 +1,4 @@
+agentstate>=1.0.2
+langgraph>=0.1.0
+langchain-core>=0.1.0
+langgraph-agentstate>=0.1.0

--- a/examples/langgraph_example/resume_agent.py
+++ b/examples/langgraph_example/resume_agent.py
@@ -1,0 +1,69 @@
+"""
+LangGraph agent that survives process restarts by checkpointing to AgentState.
+
+Run this script twice — the step counter will continue from where it left off.
+
+Requirements:
+    pip install agentstate langgraph-agentstate langgraph langchain-core
+
+Start AgentState first:
+    docker run -p 8080:8080 ayushmi/agentstate:latest
+"""
+
+import os
+from typing import TypedDict
+
+from agentstate import AgentStateClient
+from langgraph_agentstate import AgentStateCheckpointSaver
+
+try:
+    from langgraph.graph import StateGraph, END
+except ImportError:
+    print("Install langgraph: pip install langgraph langchain-core")
+    raise
+
+
+class AgentState(TypedDict):
+    messages: list
+    step: int
+
+
+def process(state: AgentState) -> AgentState:
+    """Simulate one step of work."""
+    print(f"  Processing step {state['step']} → {state['step'] + 1}")
+    return {"messages": state["messages"], "step": state["step"] + 1}
+
+
+def build_graph(saver: AgentStateCheckpointSaver):
+    g = StateGraph(AgentState)
+    g.add_node("process", process)
+    g.set_entry_point("process")
+    g.add_edge("process", END)
+    return g.compile(checkpointer=saver)
+
+
+def main():
+    url = os.environ.get("AGENTSTATE_URL", "http://localhost:8080")
+    client = AgentStateClient(url, namespace="default")
+    saver = AgentStateCheckpointSaver(client, namespace="langgraph")
+    graph = build_graph(saver)
+
+    config = {"configurable": {"thread_id": "demo-thread-001"}}
+
+    # Try to resume from existing checkpoint, or start fresh
+    existing = saver.get_tuple(config)
+    if existing:
+        current_step = existing.checkpoint.get("channel_values", {}).get("step", 0)
+        print(f"Resuming from checkpoint — current step: {current_step}")
+        init_state: AgentState = {"messages": [], "step": current_step}
+    else:
+        print("No checkpoint found — starting fresh")
+        init_state = {"messages": [], "step": 0}
+
+    result = graph.invoke(init_state, config=config)
+    print(f"Done. Step is now: {result['step']}")
+    print("Run this script again to continue from this checkpoint.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/openai_agents_example/persistent_agent.py
+++ b/examples/openai_agents_example/persistent_agent.py
@@ -1,0 +1,83 @@
+"""
+Demonstrates AgentStateStore for persisting OpenAI agent runs.
+
+This example shows the storage layer working independently.
+In production, attach the store to your Runner via run_storage=store.
+
+Requirements:
+    pip install agentstate openai-agentstate
+
+Start AgentState first:
+    docker run -p 8080:8080 ayushmi/agentstate:latest
+"""
+
+import os
+import time
+import uuid
+
+from agentstate import AgentStateClient
+from openai_agentstate import AgentStateStore
+
+
+def main():
+    url = os.environ.get("AGENTSTATE_URL", "http://localhost:8080")
+    client = AgentStateClient(url, namespace="openai-runs")
+    store = AgentStateStore(client)
+
+    # Simulate saving two runs from different agents
+    runs = [
+        {
+            "run_id": f"run_{uuid.uuid4().hex[:8]}",
+            "agent_name": "research-agent",
+            "status": "completed",
+            "input": "What is the capital of France?",
+            "output": "Paris",
+            "model": "gpt-4o",
+            "usage": {"input_tokens": 42, "output_tokens": 5},
+            "completed_at": time.time(),
+        },
+        {
+            "run_id": f"run_{uuid.uuid4().hex[:8]}",
+            "agent_name": "research-agent",
+            "status": "failed",
+            "input": "What is 2 + 2?",
+            "error": "Rate limit exceeded",
+            "model": "gpt-4o",
+            "completed_at": time.time(),
+        },
+    ]
+
+    print("Saving runs...")
+    for run in runs:
+        rid = run.pop("run_id")
+        obj = store.save_run(rid, run)
+        print(f"  Saved run {rid} → AgentState ID: {obj['id']}")
+        run["run_id"] = rid  # restore for later
+
+    print()
+
+    # Retrieve a specific run
+    rid = runs[0]["run_id"]
+    retrieved = store.get_run(rid)
+    print(f"Retrieved run {rid}:")
+    print(f"  agent: {retrieved['agent_name']}, status: {retrieved['status']}")
+    print(f"  output: {retrieved.get('output', 'N/A')}")
+    print()
+
+    # List only completed runs
+    completed = store.list_runs(agent_name="research-agent", status="completed")
+    print(f"Completed runs for research-agent: {len(completed)}")
+
+    # List all runs
+    all_runs = store.list_runs(agent_name="research-agent")
+    print(f"Total runs for research-agent: {len(all_runs)}")
+
+    # Delete one
+    store.delete_run(runs[1]["run_id"])
+    print(f"\nDeleted failed run {runs[1]['run_id']}")
+    all_runs_after = store.list_runs(agent_name="research-agent")
+    print(f"Total runs after delete: {len(all_runs_after)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/openai_agents_example/requirements.txt
+++ b/examples/openai_agents_example/requirements.txt
@@ -1,0 +1,2 @@
+agentstate>=1.0.2
+openai-agentstate>=0.1.0

--- a/examples/verification_example/check_temporal.sh
+++ b/examples/verification_example/check_temporal.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Run temporal property verification against a WAL directory.
+#
+# Usage:
+#   ./check_temporal.sh [WAL_DIR] [NAMESPACE]
+#
+# Example:
+#   ./check_temporal.sh /data/wal production
+
+set -euo pipefail
+
+WAL_DIR="${1:-.}"
+NS="${2:-verify-demo}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "=== AgentState Temporal Verification ==="
+echo "WAL dir:   $WAL_DIR"
+echo "Namespace: $NS"
+echo
+
+agentstate verify \
+  --dir "$WAL_DIR" \
+  --ns "$NS" \
+  --property "$SCRIPT_DIR/props/no_unknown_status.ltl.json" \
+  --property "$SCRIPT_DIR/props/liveness.ltl.json" \
+  --output "$SCRIPT_DIR/verify-report.json" \
+  --fail-on-violation
+
+echo
+echo "Report written to: $SCRIPT_DIR/verify-report.json"

--- a/examples/verification_example/props/liveness.ltl.json
+++ b/examples/verification_example/props/liveness.ltl.json
@@ -1,0 +1,17 @@
+{
+  "name": "active_agents_eventually_idle",
+  "kind": "liveness",
+  "description": "Any agent that becomes 'active' must eventually become 'idle' or 'stopped'",
+  "forall": { "type": "agent" },
+  "leads_to": {
+    "if":   { "field": "body.status", "eq": "active" },
+    "then": {
+      "eventually": {
+        "or": [
+          { "field": "body.status", "eq": "idle" },
+          { "field": "body.status", "eq": "stopped" }
+        ]
+      }
+    }
+  }
+}

--- a/examples/verification_example/props/no_unknown_status.ltl.json
+++ b/examples/verification_example/props/no_unknown_status.ltl.json
@@ -1,0 +1,9 @@
+{
+  "name": "status_never_unknown",
+  "kind": "safety",
+  "description": "body.status must never equal 'unknown' across all versions",
+  "forall": { "type": "agent" },
+  "always": {
+    "not": { "field": "body.status", "eq": "unknown" }
+  }
+}

--- a/examples/verification_example/requirements.txt
+++ b/examples/verification_example/requirements.txt
@@ -1,0 +1,2 @@
+agentstate>=1.0.2
+requests>=2.28.0

--- a/examples/verification_example/setup_invariants.py
+++ b/examples/verification_example/setup_invariants.py
@@ -1,0 +1,92 @@
+"""
+Demonstration of AgentState runtime invariant assertions (Layer 2).
+
+Run with:
+    docker run -p 8080:8080 ayushmi/agentstate:latest
+    pip install -r requirements.txt
+    python setup_invariants.py
+"""
+
+import requests
+from agentstate import AgentStateClient
+
+BASE_URL = "http://localhost:8080"
+NS = "verify-demo"
+
+client = AgentStateClient(BASE_URL, NS)
+
+
+def main():
+    print("=== AgentState Invariant Demo ===\n")
+
+    # 1. Set a namespace invariant
+    print("1. Setting invariant on namespace:", NS)
+    spec = client.set_invariant(NS, [
+        {"field": "body.status",   "required": True, "one_of": ["active", "idle", "stopped"]},
+        {"field": "body.score",    "gte": 0.0, "lte": 1.0},
+        {"field": "body.agent_id", "required": True, "type": "string"},
+    ])
+    print("   Stored spec:", spec)
+
+    # 2. Write a valid object — should succeed
+    print("\n2. Writing a valid object...")
+    obj = client.create_agent("agent", {
+        "agent_id": "agent-001",
+        "status": "active",
+        "score": 0.85,
+    }, tags={"team": "platform"})
+    print("   Created:", obj["id"], "commit:", obj["commit"][:8])
+
+    # 3. Upsert the same object — should succeed
+    print("\n3. Updating status to 'idle'...")
+    obj2 = client.create_agent("agent", {
+        "agent_id": "agent-001",
+        "status": "idle",
+        "score": 0.72,
+    }, tags={"team": "platform"}, agent_id=obj["id"])
+    print("   Updated:", obj2["id"], "prev_commit:", obj2.get("prev_commit", "n/a")[:8])
+
+    # 4. Try an invalid write — status not in allowed list
+    print("\n4. Attempting write with invalid status 'unknown'...")
+    try:
+        client.create_agent("agent", {
+            "agent_id": "agent-002",
+            "status": "unknown",   # not in one_of
+            "score": 0.5,
+        })
+        print("   ERROR: should have been rejected!")
+    except requests.HTTPError as e:
+        resp = e.response.json()
+        print("   Correctly rejected (409):")
+        for v in resp.get("violations", []):
+            print("    -", v)
+
+    # 5. Try an invalid score
+    print("\n5. Attempting write with score out of range (1.5)...")
+    try:
+        client.create_agent("agent", {
+            "agent_id": "agent-003",
+            "status": "active",
+            "score": 1.5,   # > 1.0
+        })
+        print("   ERROR: should have been rejected!")
+    except requests.HTTPError as e:
+        resp = e.response.json()
+        print("   Correctly rejected (409):")
+        for v in resp.get("violations", []):
+            print("    -", v)
+
+    # 6. Chain verify
+    print("\n6. Verifying hash chain...")
+    r = requests.get(f"{BASE_URL}/admin/namespaces/{NS}/chain-verify")
+    data = r.json()
+    if data["ok"]:
+        print(f"   Chain intact — {data['objects_checked']} objects checked, 0 breaks")
+    else:
+        print("   Chain BROKEN:", data["breaks"])
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -1,0 +1,26 @@
+AgentState Gateway (Hosted Playground + Billing)
+
+Overview
+- Issues capability tokens per user/namespace using the server’s HMAC format.
+- Proxies REST calls to the AgentState server and meters usage per request.
+- Integrates with Stripe Billing for free tier + pay-as-you-go (optional for OSS).
+
+Endpoints
+- POST /api/token: Returns a short‑lived capability token and namespace.
+- ANY /v1/*: Reverse proxy to AgentState; injects Authorization and meters usage.
+- POST /webhook: Stripe webhooks (optional), usage reconciliation.
+
+Quick Start (Dev)
+1. set env:
+   - CAP_KEY_ACTIVE_ID=active
+   - CAP_KEY_ACTIVE=dev-secret
+   - UPSTREAM_BASE=http://localhost:8080
+   - FREE_MAX_QPS=5
+   - FREE_MAX_BYTES=262144
+2. run: npm install && npm run dev
+3. open docs/playground and set localStorage as.gateway to http://localhost:8787
+
+Notes
+- SSE cannot carry Authorization headers; for watch, the proxy endpoint should be used (e.g., /v1/:ns/watch via this gateway).
+- For production, back usage counters by Redis/Postgres and flush usage to Stripe metered prices using Usage Records.
+

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "agentstate-gateway",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "node --watch src/server.js",
+    "start": "node src/server.js"
+  },
+  "dependencies": {
+    "cookie": "^0.6.0",
+    "express": "^4.19.2",
+    "http-proxy-middleware": "^3.0.0",
+    "nanoid": "^5.0.7",
+    "stripe": "^16.0.0"
+  }
+}
+

--- a/gateway/src/server.js
+++ b/gateway/src/server.js
@@ -1,0 +1,86 @@
+import express from 'express';
+import { createProxyMiddleware } from 'http-proxy-middleware';
+import crypto from 'crypto';
+import { nanoid } from 'nanoid';
+import cookie from 'cookie';
+
+// Config
+const PORT = process.env.PORT || 8787;
+const UPSTREAM_BASE = process.env.UPSTREAM_BASE || 'http://localhost:8080';
+const CAP_ID = process.env.CAP_KEY_ACTIVE_ID || 'active';
+const CAP_SECRET = process.env.CAP_KEY_ACTIVE || 'dev-secret';
+const FREE_MAX_QPS = parseInt(process.env.FREE_MAX_QPS || '5', 10);
+const FREE_MAX_BYTES = parseInt(process.env.FREE_MAX_BYTES || '262144', 10); // 256KB
+
+// Simple in-memory usage counters (replace with Redis/Postgres in prod)
+const usage = new Map(); // key: ns, value: { ops: number, lastFlush: number }
+
+const app = express();
+app.use(express.json());
+
+// Utility: base64url without padding
+function b64url(buf) {
+  return Buffer.from(buf).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function createCapToken({ ns, verbs, expSec = 24 * 3600, maxQps = FREE_MAX_QPS, maxBytes = FREE_MAX_BYTES, region = '' }) {
+  const exp = Math.floor(Date.now() / 1000) + expSec;
+  const jti = nanoid();
+  const claims = { ns: [ns], verbs, exp, max_qps: maxQps, max_bytes: maxBytes, region, jti };
+  const payload = b64url(JSON.stringify(claims));
+  const mac = crypto.createHmac('sha256', CAP_SECRET);
+  mac.update(Buffer.from(payload));
+  const sig = b64url(mac.digest());
+  return `${CAP_ID}.${payload}.${sig}`;
+}
+
+// Very lightweight demo auth: namespace cookie or anonymous new ns
+function getOrCreateNamespace(req, res) {
+  const cookies = cookie.parse(req.headers.cookie || '');
+  let ns = cookies['as_ns'];
+  if (!ns) {
+    ns = `demo-${nanoid(8)}`;
+    res.setHeader('Set-Cookie', cookie.serialize('as_ns', ns, { httpOnly: true, sameSite: 'Lax', path: '/', maxAge: 86400 * 7 }));
+  }
+  return ns;
+}
+
+app.post('/api/token', (req, res) => {
+  const ns = getOrCreateNamespace(req, res);
+  const token = createCapToken({ ns, verbs: ['put', 'get', 'query', 'delete', 'watch', 'lease'] });
+  res.json({ baseUrl: process.env.PUBLIC_BASE || `http://localhost:${PORT}`, namespace: ns, token });
+});
+
+// Usage middleware: counts 1 op per request (tunable per method)
+function meter(req, res, next) {
+  // Only count API paths
+  if (!req.path.startsWith('/v1/')) return next();
+  const ns = (req.params && req.params.ns) || (req.path.split('/')[2] || 'unknown');
+  const rec = usage.get(ns) || { ops: 0, lastFlush: Date.now() };
+  rec.ops += 1;
+  usage.set(ns, rec);
+  next();
+}
+
+// Inject Authorization on the way to upstream. Note: SSE watch must go through this gateway to carry auth.
+const injectAuth = (proxyReq, req, res) => {
+  const cookies = cookie.parse(req.headers.cookie || '');
+  const ns = cookies['as_ns'] || (req.path.split('/')[2] || 'demo');
+  const token = createCapToken({ ns, verbs: ['put', 'get', 'query', 'delete', 'watch', 'lease'] });
+  proxyReq.setHeader('Authorization', `Bearer ${token}`);
+};
+
+app.use('/v1', meter, createProxyMiddleware({
+  target: UPSTREAM_BASE,
+  changeOrigin: true,
+  pathRewrite: (path) => path, // keep as-is
+  onProxyReq: injectAuth,
+  ws: true,
+}));
+
+app.get('/health', (_req, res) => res.json({ ok: true }));
+
+app.listen(PORT, () => {
+  console.log(`AgentState gateway listening on :${PORT}, upstream=${UPSTREAM_BASE}`);
+});
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,9 @@
 {
-  "name": "agentstate-quickstart",
-  "version": "1.0.0",
+  "name": "AgentState",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "agentstate-quickstart",
-      "version": "1.0.0",
       "dependencies": {
         "agentstate": "^1.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "agentstate": "^1.0.2"
+  }
+}

--- a/proto/agentstate.proto
+++ b/proto/agentstate.proto
@@ -1,6 +1,12 @@
 syntax = "proto3";
 package agentstate.v1;
 
+message Cause {
+  string actor   = 1; // agent ID making this change (empty = absent)
+  string trigger = 2; // commit hash that triggered this (empty = absent)
+  string note    = 3; // human-readable reason (empty = absent)
+}
+
 message Object {
   string id = 1;
   string ns = 2;
@@ -11,6 +17,7 @@ message Object {
   repeated string parents = 7;
   string commit = 8;
   string ts_rfc3339 = 9;
+  Cause cause = 10;
 }
 
 message PutRequest {
@@ -21,6 +28,7 @@ message PutRequest {
   uint64 ttl_seconds = 5;
   repeated string parents = 6;
   string id = 7; // optional
+  Cause cause = 8;
 }
 
 message GetRequest { string ns = 1; string id = 2; string at_ts_rfc3339 = 3; }

--- a/sdk-go/README.md
+++ b/sdk-go/README.md
@@ -1,0 +1,98 @@
+# AgentState Go SDK
+
+Go client for [AgentState](https://github.com/ayushmi/agentstate) — "Firebase for AI Agents".
+
+**stdlib only** — no external dependencies.
+
+## Install
+
+```bash
+go get github.com/ayushmi/agentstate/sdk-go
+```
+
+## Quick Start
+
+```go
+import agentstate "github.com/ayushmi/agentstate/sdk-go/agentstate"
+
+client := agentstate.NewClient("http://localhost:8080", "production",
+    agentstate.WithAPIKey(os.Getenv("AGENTSTATE_API_KEY")),
+)
+
+// Create or update an agent
+obj, err := client.Put(agentstate.PutRequest{
+    Type: "agent",
+    Body: map[string]any{"status": "active", "name": "worker-1"},
+    Tags: agentstate.Tags{"env": "production", "team": "platform"},
+    Cause: &agentstate.Cause{
+        Actor: "scheduler",
+        Note:  "initial deployment",
+    },
+})
+
+// Get latest version
+obj, err = client.Get(obj.ID, time.Time{})
+
+// Get state as of 10 minutes ago (time-travel)
+old, err := client.Get(obj.ID, time.Now().Add(-10*time.Minute))
+
+// Query by tags
+agents, err := client.Query(agentstate.Tags{"env": "production", "status": "active"})
+
+// Watch for real-time changes
+err = client.Watch(func(ev agentstate.WatchEvent) bool {
+    fmt.Printf("[%s] %s\n", ev.Type, ev.ID)
+    return true // return false to stop
+})
+
+// Delete
+err = client.Delete(obj.ID)
+```
+
+## API
+
+| Method | Description |
+|--------|-------------|
+| `NewClient(baseURL, namespace, opts...)` | Create a client |
+| `WithAPIKey(key)` | Option: set Bearer token |
+| `WithHTTPClient(hc)` | Option: set custom http.Client |
+| `Put(PutRequest)` | Create or update an object |
+| `Get(id, atTime)` | Get object; pass `time.Time{}` for latest, non-zero for time-travel |
+| `Query(tags)` | List objects matching all tags |
+| `Delete(id)` | Delete an object |
+| `Watch(fn)` | Stream SSE events; return false from fn to stop |
+| `Health()` | Returns true if server is healthy |
+
+## Types
+
+```go
+type PutRequest struct {
+    Type       string
+    Body       map[string]any
+    Tags       Tags
+    ID         string      // optional stable ID for upserts
+    Parents    []string    // optional parent commit hashes
+    Cause      *Cause      // optional provenance
+}
+
+type Cause struct {
+    Actor   string // agent ID making this change
+    Trigger string // commit hash that triggered this
+    Note    string // human-readable reason
+}
+
+type Object struct {
+    ID, Namespace, Type string
+    Body                map[string]any
+    Tags                Tags
+    Commit              string
+    CommitSeq           uint64
+    Timestamp           time.Time
+    Cause               *Cause
+}
+```
+
+## Requirements
+
+- Go 1.21+
+- AgentState server ([quickstart](https://github.com/ayushmi/agentstate#quick-start))

--- a/sdk-go/agentstate/client.go
+++ b/sdk-go/agentstate/client.go
@@ -220,3 +220,38 @@ func (c *Client) Health() bool {
 	defer resp.Body.Close()
 	return resp.StatusCode == 200
 }
+
+// SetInvariant configures a namespace invariant (enforced before every write).
+// rules is a slice of rule maps, e.g.:
+//
+//	[]map[string]any{
+//	    {"field": "body.status", "required": true},
+//	    {"field": "body.score", "gte": 0, "lte": 1},
+//	}
+func (c *Client) SetInvariant(ns string, rules []map[string]any) (map[string]any, error) {
+	payload := map[string]any{"rules": rules}
+	hreq, err := c.newRequest("POST", fmt.Sprintf("/admin/namespaces/%s/invariants", ns), payload)
+	if err != nil {
+		return nil, err
+	}
+	var result map[string]any
+	return result, c.do(hreq, &result)
+}
+
+// GetInvariant retrieves the current invariant spec for a namespace.
+// Returns nil, nil if no invariant is set.
+func (c *Client) GetInvariant(ns string) (map[string]any, error) {
+	hreq, err := c.newRequest("GET", fmt.Sprintf("/admin/namespaces/%s/invariants", ns), nil)
+	if err != nil {
+		return nil, err
+	}
+	var result map[string]any
+	if err := c.do(hreq, &result); err != nil {
+		// 404 means no invariant set — treat as nil, nil
+		if strings.Contains(err.Error(), "status 404") {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return result, nil
+}

--- a/sdk-go/agentstate/client.go
+++ b/sdk-go/agentstate/client.go
@@ -1,0 +1,222 @@
+package agentstate
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Client is the AgentState HTTP client for Go.
+//
+// Example:
+//
+//	client := agentstate.NewClient("http://localhost:8080", "production")
+//	obj, err := client.Put(agentstate.PutRequest{
+//	    Type: "agent",
+//	    Body: map[string]any{"status": "active"},
+//	    Tags: agentstate.Tags{"env": "prod"},
+//	})
+type Client struct {
+	baseURL   string
+	namespace string
+	apiKey    string
+	http      *http.Client
+}
+
+// ClientOption is a functional option for configuring a Client.
+type ClientOption func(*Client)
+
+// WithAPIKey sets the API key sent as "Authorization: Bearer <key>" on every request.
+func WithAPIKey(key string) ClientOption {
+	return func(c *Client) { c.apiKey = key }
+}
+
+// WithHTTPClient replaces the default http.Client (e.g. to configure TLS or timeouts).
+func WithHTTPClient(hc *http.Client) ClientOption {
+	return func(c *Client) { c.http = hc }
+}
+
+// NewClient creates a new AgentState client for the given server URL and namespace.
+//
+//	client := agentstate.NewClient("http://localhost:8080", "production")
+//	client := agentstate.NewClient("http://localhost:8080", "production",
+//	    agentstate.WithAPIKey(os.Getenv("AGENTSTATE_API_KEY")),
+//	)
+func NewClient(baseURL, namespace string, opts ...ClientOption) *Client {
+	c := &Client{
+		baseURL:   strings.TrimRight(baseURL, "/"),
+		namespace: namespace,
+		http:      &http.Client{Timeout: 30 * time.Second},
+	}
+	for _, o := range opts {
+		o(c)
+	}
+	return c
+}
+
+func (c *Client) newRequest(method, path string, body any) (*http.Request, error) {
+	var buf io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("agentstate: marshal request: %w", err)
+		}
+		buf = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, c.baseURL+path, buf)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "agentstate-go-sdk/0.1.0")
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+	return req, nil
+}
+
+func (c *Client) do(req *http.Request, out any) error {
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("agentstate: %w", err)
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("agentstate: read response: %w", err)
+	}
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("agentstate: status %d: %s", resp.StatusCode, data)
+	}
+	if out != nil {
+		if err := json.Unmarshal(data, out); err != nil {
+			return fmt.Errorf("agentstate: decode response: %w", err)
+		}
+	}
+	return nil
+}
+
+// Put creates or updates an object in the client's namespace.
+//
+//	obj, err := client.Put(agentstate.PutRequest{
+//	    Type: "agent",
+//	    Body: map[string]any{"status": "active"},
+//	    Tags: agentstate.Tags{"env": "prod"},
+//	    Cause: &agentstate.Cause{Actor: "scheduler", Note: "initial setup"},
+//	})
+func (c *Client) Put(req PutRequest) (*Object, error) {
+	hreq, err := c.newRequest("POST", fmt.Sprintf("/v1/%s/objects", c.namespace), req)
+	if err != nil {
+		return nil, err
+	}
+	var obj Object
+	return &obj, c.do(hreq, &obj)
+}
+
+// Get retrieves an object by ID.
+// Pass a zero time.Time{} to get the latest version.
+// Pass a non-zero time to use the server's time-travel feature (?at=<RFC3339>).
+//
+//	// Latest version
+//	obj, err := client.Get("01JXYZ...", time.Time{})
+//
+//	// State as of 10 minutes ago
+//	obj, err := client.Get("01JXYZ...", time.Now().Add(-10*time.Minute))
+func (c *Client) Get(id string, atTime time.Time) (*Object, error) {
+	path := fmt.Sprintf("/v1/%s/objects/%s", c.namespace, id)
+	if !atTime.IsZero() {
+		path += "?at=" + atTime.UTC().Format(time.RFC3339)
+	}
+	hreq, err := c.newRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var obj Object
+	return &obj, c.do(hreq, &obj)
+}
+
+// Query lists objects in the namespace matching all provided tags.
+// Pass nil or empty Tags to return all objects.
+//
+//	agents, err := client.Query(agentstate.Tags{"env": "prod", "status": "active"})
+func (c *Client) Query(tags Tags) ([]Object, error) {
+	payload := map[string]any{}
+	if len(tags) > 0 {
+		payload["tag_filter"] = tags
+	}
+	hreq, err := c.newRequest("POST", fmt.Sprintf("/v1/%s/query", c.namespace), payload)
+	if err != nil {
+		return nil, err
+	}
+	var objs []Object
+	return objs, c.do(hreq, &objs)
+}
+
+// Delete removes an object by ID.
+func (c *Client) Delete(id string) error {
+	hreq, err := c.newRequest("DELETE", fmt.Sprintf("/v1/%s/objects/%s", c.namespace, id), nil)
+	if err != nil {
+		return err
+	}
+	return c.do(hreq, nil)
+}
+
+// Watch subscribes to the Server-Sent Events watch stream for the client's namespace.
+// fn is called for each event. Return false from fn to stop watching.
+// Watch blocks until fn returns false, the stream ends, or an error occurs.
+//
+//	err := client.Watch(func(ev agentstate.WatchEvent) bool {
+//	    fmt.Printf("event: %s id: %s\n", ev.Type, ev.ID)
+//	    return true // keep watching
+//	})
+func (c *Client) Watch(fn WatchFunc) error {
+	url := fmt.Sprintf("%s/v1/%s/watch", c.baseURL, c.namespace)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Cache-Control", "no-cache")
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("agentstate: watch connect: %w", err)
+	}
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	var dataLine string
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "data:") {
+			dataLine = strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		} else if line == "" && dataLine != "" {
+			var ev WatchEvent
+			if err := json.Unmarshal([]byte(dataLine), &ev); err == nil {
+				if !fn(ev) {
+					return nil
+				}
+			}
+			dataLine = ""
+		}
+	}
+	return scanner.Err()
+}
+
+// Health returns true if the AgentState server is reachable and healthy.
+func (c *Client) Health() bool {
+	resp, err := c.http.Get(c.baseURL + "/health")
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == 200
+}

--- a/sdk-go/agentstate/client_test.go
+++ b/sdk-go/agentstate/client_test.go
@@ -1,0 +1,61 @@
+package agentstate_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	agentstate "github.com/ayushmi/agentstate/sdk-go/agentstate"
+)
+
+// TestNewClient verifies the client can be constructed without panicking.
+func TestNewClient(t *testing.T) {
+	client := agentstate.NewClient("http://localhost:8080", "test",
+		agentstate.WithAPIKey("test-key"),
+	)
+	if client == nil {
+		t.Fatal("expected non-nil client")
+	}
+}
+
+// Example shows typical usage of the Go SDK.
+// This is an example function — it won't run without a live server,
+// but it documents the API and is checked by `go build`.
+func Example() {
+	client := agentstate.NewClient("http://localhost:8080", "go-example")
+
+	// Create an object
+	obj, err := client.Put(agentstate.PutRequest{
+		Type: "agent",
+		Body: map[string]any{"status": "active", "name": "worker-1"},
+		Tags: agentstate.Tags{"env": "production"},
+		Cause: &agentstate.Cause{
+			Actor: "scheduler",
+			Note:  "initial deployment",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Created:", obj.ID)
+
+	// Retrieve latest version
+	got, err := client.Get(obj.ID, time.Time{})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Status:", got.Body["status"])
+
+	// Retrieve as of 1 hour ago (time-travel)
+	_, _ = client.Get(obj.ID, time.Now().Add(-time.Hour))
+
+	// Query by tag
+	agents, err := client.Query(agentstate.Tags{"env": "production"})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Found agents:", len(agents))
+
+	// Delete
+	_ = client.Delete(obj.ID)
+}

--- a/sdk-go/agentstate/types.go
+++ b/sdk-go/agentstate/types.go
@@ -1,0 +1,52 @@
+// Package agentstate provides a Go client for the AgentState HTTP API.
+package agentstate
+
+import "time"
+
+// Tags is a map of string key-value pairs used for querying objects.
+type Tags map[string]string
+
+// Cause records why a state change happened. All fields are optional.
+type Cause struct {
+	Actor   string `json:"actor,omitempty"`   // agent ID making this change
+	Trigger string `json:"trigger,omitempty"` // commit hash that triggered this change
+	Note    string `json:"note,omitempty"`    // human-readable reason
+}
+
+// Object is a persisted AgentState object returned by the server.
+type Object struct {
+	ID         string         `json:"id"`
+	Namespace  string         `json:"ns"`
+	Type       string         `json:"type"`
+	Body       map[string]any `json:"body"`
+	Tags       Tags           `json:"tags"`
+	TTLSeconds *uint64        `json:"ttl_seconds,omitempty"`
+	Parents    []string       `json:"parents,omitempty"`
+	Commit     string         `json:"commit"`
+	Timestamp  time.Time      `json:"ts"`
+	CommitSeq  uint64         `json:"commit_seq"`
+	Cause      *Cause         `json:"cause,omitempty"`
+}
+
+// PutRequest is the payload for creating or updating an object.
+type PutRequest struct {
+	Type       string         `json:"type"`
+	Body       map[string]any `json:"body"`
+	Tags       Tags           `json:"tags,omitempty"`
+	TTLSeconds *uint64        `json:"ttl_seconds,omitempty"`
+	ID         string         `json:"id,omitempty"`
+	Parents    []string       `json:"parents,omitempty"`
+	Cause      *Cause         `json:"cause,omitempty"`
+}
+
+// WatchEvent is a parsed Server-Sent Event from the watch stream.
+type WatchEvent struct {
+	Type      string  `json:"type"`              // "put" or "delete"
+	Obj       *Object `json:"obj,omitempty"`     // present for "put" events
+	ID        string  `json:"id,omitempty"`      // present for "delete" events
+	CommitSeq uint64  `json:"commit_seq,omitempty"`
+}
+
+// WatchFunc is called for each SSE event received from the watch stream.
+// Return false to stop watching.
+type WatchFunc func(event WatchEvent) bool

--- a/sdk-go/go.mod
+++ b/sdk-go/go.mod
@@ -1,0 +1,3 @@
+module github.com/ayushmi/agentstate/sdk-go
+
+go 1.21

--- a/sdk-py/agentstate/client.py
+++ b/sdk-py/agentstate/client.py
@@ -244,3 +244,42 @@ class AgentStateClient:
         r = requests.post(f"{self.base_url}/v1/{self.namespace}/lease/release", json={"key": key, "owner": owner, "token": token})
         r.raise_for_status()
         return True
+
+    # ── Invariant management ──────────────────────────────────────────────────
+
+    def set_invariant(self, ns: str, rules: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Set a namespace invariant (predicate spec) that is enforced on every write.
+
+        Args:
+            ns: Namespace to protect.
+            rules: List of rule dicts, e.g.
+                   [{"field": "body.status", "required": True},
+                    {"field": "body.score", "gte": 0, "lte": 1}]
+
+        Returns:
+            The stored spec as returned by the server.
+
+        Raises:
+            requests.HTTPError: On server error (400 for invalid spec, 401/403 for auth).
+        """
+        resp = self.session.post(
+            f"{self.base_url}/admin/namespaces/{ns}/invariants",
+            json={"rules": rules},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_invariant(self, ns: str) -> Optional[Dict[str, Any]]:
+        """Retrieve the current invariant spec for a namespace, or None if none is set.
+
+        Args:
+            ns: Namespace to query.
+
+        Returns:
+            The spec dict, or None if no invariant has been configured.
+        """
+        resp = self.session.get(f"{self.base_url}/admin/namespaces/{ns}/invariants")
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        return resp.json()

--- a/sdk-py/agentstate/client.py
+++ b/sdk-py/agentstate/client.py
@@ -47,29 +47,34 @@ class AgentStateClient:
         if api_key:
             self.session.headers['Authorization'] = f'Bearer {api_key}'
 
-    def create_agent(self, agent_type: str, body: Dict[str, Any], 
-                    tags: Optional[Dict[str, str]] = None, 
-                    agent_id: Optional[str] = None) -> Dict[str, Any]:
+    def create_agent(self, agent_type: str, body: Dict[str, Any],
+                    tags: Optional[Dict[str, str]] = None,
+                    agent_id: Optional[str] = None,
+                    cause: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
         """
         Create or update an agent.
-        
+
         Args:
-            agent_type: Type of agent (e.g., "chatbot", "workflow", "classifier")  
+            agent_type: Type of agent (e.g., "chatbot", "workflow", "classifier")
             body: Agent state data (any JSON-serializable object)
             tags: Key-value pairs for querying and organization
             agent_id: Specific ID to use (for updates), auto-generated if None
-            
+            cause: Why this change happened, e.g. {"actor": "planner-1", "note": "retrying task"}
+                   Supported keys: actor (agent ID), trigger (commit hash), note (free text)
+
         Returns:
             Created agent object with id, type, body, tags, commit_seq, commit_ts
         """
-        payload = {
+        payload: Dict[str, Any] = {
             "type": agent_type,
             "body": body,
             "tags": tags or {}
         }
         if agent_id:
             payload["id"] = agent_id
-            
+        if cause:
+            payload["cause"] = cause
+
         response = self.session.post(f"{self.base_url}/v1/{self.namespace}/objects", json=payload)
         response.raise_for_status()
         return response.json()
@@ -133,11 +138,12 @@ class AgentStateClient:
             return False
 
     # Legacy API compatibility
-    def put(self, typ: str, body: Dict[str, Any], tags: Optional[Dict[str, str]] = None, 
-            ttl_seconds: Optional[int] = None, id: Optional[str] = None, 
-            idempotency_key: Optional[str] = None) -> Dict[str, Any]:
+    def put(self, typ: str, body: Dict[str, Any], tags: Optional[Dict[str, str]] = None,
+            ttl_seconds: Optional[int] = None, id: Optional[str] = None,
+            idempotency_key: Optional[str] = None,
+            cause: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
         """Legacy method for backward compatibility. Use create_agent() instead."""
-        return self.create_agent(typ, body, tags, id)
+        return self.create_agent(typ, body, tags, id, cause=cause)
 
     def get(self, id: str) -> Dict[str, Any]:
         """Legacy method for backward compatibility. Use get_agent() instead."""

--- a/sdk-ts/package-lock.json
+++ b/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentstate",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentstate",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0"

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -2,6 +2,25 @@ import axios, { AxiosInstance } from 'axios';
 
 export type Tags = Record<string, string>;
 
+/** A single rule in a namespace invariant spec. */
+export interface InvariantRule {
+  field: string;                      // "body.<key>" or "tags.<key>"
+  required?: boolean;
+  type?: 'string' | 'number' | 'bool' | 'array' | 'object';
+  eq?: any;
+  one_of?: any[];
+  gte?: number;
+  lte?: number;
+  gt?: number;
+  lt?: number;
+  regex?: string;
+}
+
+/** Namespace invariant spec — a set of rules enforced on every write. */
+export interface InvariantSpec {
+  rules: InvariantRule[];
+}
+
 /** Records why a state change happened. All fields are optional. */
 export interface Cause {
   actor?: string;   // agent ID making this change
@@ -168,6 +187,33 @@ export class AgentStateClient {
       return response.status === 200 && response.data.trim() === 'ok';
     } catch {
       return false;
+    }
+  }
+
+  // ── Invariant management ────────────────────────────────────────────────────
+
+  /**
+   * Set a namespace invariant that is enforced on every write.
+   * @param ns - Namespace to protect (can differ from the client's namespace).
+   * @param rules - Array of rule objects, e.g. [{field:"body.status", required:true}]
+   * @returns The stored spec as returned by the server.
+   */
+  async setInvariant(ns: string, rules: InvariantRule[]): Promise<InvariantSpec> {
+    const resp = await this.http.post(`${this.baseUrl}/admin/namespaces/${ns}/invariants`, { rules });
+    return resp.data;
+  }
+
+  /**
+   * Retrieve the current invariant spec for a namespace.
+   * @returns The spec, or null if no invariant is set.
+   */
+  async getInvariant(ns: string): Promise<InvariantSpec | null> {
+    try {
+      const resp = await this.http.get(`${this.baseUrl}/admin/namespaces/${ns}/invariants`);
+      return resp.data;
+    } catch (e: any) {
+      if (e?.response?.status === 404) return null;
+      throw e;
     }
   }
 

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -2,6 +2,13 @@ import axios, { AxiosInstance } from 'axios';
 
 export type Tags = Record<string, string>;
 
+/** Records why a state change happened. All fields are optional. */
+export interface Cause {
+  actor?: string;   // agent ID making this change
+  trigger?: string; // commit hash that triggered this change
+  note?: string;    // human-readable reason
+}
+
 export interface Agent {
   id: string;
   type: string;
@@ -9,6 +16,7 @@ export interface Agent {
   tags: Tags;
   commit_seq: number;
   commit_ts: string;
+  cause?: Cause;
 }
 
 /**
@@ -81,26 +89,26 @@ export class AgentStateClient {
    * @returns Created agent object with id, type, body, tags, commit_seq, commit_ts
    */
   async createAgent(
-    agentType: string, 
-    body: any, 
-    tags?: Tags, 
-    agentId?: string
+    agentType: string,
+    body: any,
+    tags?: Tags,
+    agentId?: string,
+    cause?: Cause
   ): Promise<Agent> {
     const payload: any = {
       type: agentType,
       body,
       tags: tags || {}
     };
-    
-    if (agentId) {
-      payload.id = agentId;
-    }
+
+    if (agentId) payload.id = agentId;
+    if (cause) payload.cause = cause;
 
     const response = await this.http.post(
       `${this.baseUrl}/v1/${this.namespace}/objects`,
       payload
     );
-    
+
     return response.data;
   }
 
@@ -171,8 +179,8 @@ export class AgentStateClient {
   /**
    * @deprecated Use createAgent() instead
    */
-  async put(type: string, body: any, tags?: Tags, ttl_seconds?: number, id?: string): Promise<Agent> {
-    return this.createAgent(type, body, tags, id);
+  async put(type: string, body: any, tags?: Tags, ttl_seconds?: number, id?: string, cause?: Cause): Promise<Agent> {
+    return this.createAgent(type, body, tags, id, cause);
   }
 
   /**


### PR DESCRIPTION
This PR introduces a self-contained chaos testing harness and CI workflow for Phase‑1 (single‑node) durability/availability validation.

What’s included
- Harness under `AgentStateTesting/chaos` with:
  - Workload: concurrent writers/readers driving public HTTP API.
  - Watcher: SSE consumer validating monotonic commit sequence and last-value agreement across nemeses.
  - Nemeses: pause/unpause (stall surrogate), crash/recovery, and disk‑full (tmpfs).
- Compose overlay: size‑limited tmpfs at `/data`, stable container name, test‑only Debian runtime with tools.
- CI: `.github/workflows/chaos-ci.yml` runs on PRs/nightly; prints container logs on failure.
- Metric assertions: ensure `watch_drops_total{reason="overflow"} == 0`, `watch_clients{proto="sse"} >= 1`, and `watch_events_total > 0`.

Notes
- No server/runtime code changes.
- SSE resumes aren’t counted yet (only gRPC does); left as a follow‑up if desired.
- Disk‑full is induced by filling tmpfs; we then free space and verify write recovery.

Follow‑ups (separate PRs)
- Add watch-stream soaks to nightly.
- Optional: track SSE resumes metric; clarify delete labeling in `watch_events_total`.
- Expand to true network partitions once clustering lands.

Signed-off-by: Ayush Mittal <ayushsmittal@gmail.com>
